### PR TITLE
Frontend Install Guide + Some Minor Fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,27 @@
+# Database credentials
+DB_PASSWORD=password
+DB_USER=postgres
+DB_NAME=jiten
+DB_HOST=postgres
+
+# API configuration
+STATIC_FILES_PATH=/app/uploads
+USE_BUNNYCDN=false
+BUNNYCDN_SECRET=
+BUNNYCDN_STORAGE_ZONE=
+CDN_BASE_URL=
+DICTIONARY_PATH=/path/to/system_full.dic
+JIMAKU_API_KEY=
+TMDB_API_KEY=
+DOTNET_ENVIRONMENT=Development
+
+# Web configuration
+API_BASE_URL=http://localhost:8080/api
+UMAMI_ANALYTICS_WEBSITE_ID=
+UMAMI_ANALYTICS_HOST_URL=http://localhost:3005
+
+# Umami analytics service configuration
+UMAMI_APP_SECRET=replace-me-with-a-random-string
+UMAMI_HASH_SALT=some-random-string
+UMAMI_TRACKER_SCRIPT_NAME=umm.js
+

--- a/.gitignore
+++ b/.gitignore
@@ -287,3 +287,6 @@ __pycache__/
 *.btm.cs
 *.odx.cs
 *.xsd.cs
+
+# Environment Files
+.env

--- a/Jiten.Web/docker-compose.yml
+++ b/Jiten.Web/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.8'
+
+services:
+  jiten-web:
+    build: .
+    ports:
+      - "3001:3001"
+    environment:
+      - NUXT_HOST=0.0.0.0
+      - NUXT_PORT=3001
+      - PORT=3001
+    restart: unless-stopped

--- a/README.md
+++ b/README.md
@@ -7,7 +7,88 @@
 - [JmdictFurigana](https://github.com/Doublevil/JmdictFurigana) Furigana dictionary for JMDict
 
 # Installation
-Coming soon.
+
+## System Requirements
+
+- **Operating System:** Linux, macOS, or Windows (with Docker support)
+- **CPU & Memory:** Minimum 2 CPU cores and 4GB of RAM recommended for development
+- **Ports:** Ensure ports `8080`, `3001`, and `3005` are available for the API, web, and Umami services respectively
+
+## Prerequisites
+
+Before you begin, make sure you have the following installed on your machine:
+
+- **Docker:** [Download and install Docker](https://docs.docker.com/get-docker/)
+- **Docker Compose:** [Download and install Docker Compose](https://docs.docker.com/compose/install/)
+- **Git:** To clone the repository ([Download Git](https://git-scm.com/downloads))
+
+## Installation Steps
+
+### 1. Clone the Repository
+
+Open your terminal and run the following command to clone the repository:
+
+```bash
+git clone https://github.com/Sirush/Jiten.git
+cd Jiten
+```
+
+### 2. Configure Environment Variables
+
+The project uses an environment file to set various configuration options for the services. Follow these steps:
+
+1. Copy the provided `.env.example` file to a new file named `.env`:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+2. Open the `.env` file in your favorite text editor and modify the variables as needed.
+
+### 3. Start the Services
+
+With Docker and Docker Compose installed and the environment variables configured, you can now start the application:
+
+1. Open a terminal in the project root directory.
+2. Run the following command to spin up the services:
+
+   ```bash
+   docker-compose up -d
+   ```
+
+   This command will:
+   - Build and run the API and Web services using their respective Dockerfiles.
+   - Pull and run the Postgres and Umami containers.
+   - Create and attach the required volumes.
+
+## Services Overview
+
+- **Postgres:**
+  - Database for the project.
+
+- **API:**
+  - Built from the `Jiten.Api/Dockerfile`.
+  - Exposes port `8080`.
+
+- **Web:**
+  - Nuxt frontend.
+  - Built from the `Jiten.Web/Dockerfile`.
+  - Exposes port `3001`.
+
+- **Umami:**
+  - A web analytics tool based on Umami running with PostgreSQL.
+  - Exposes port `3005`.
+
+## Additional Notes
+
+- **Traefik Labels:**  
+  The services are configured with Traefik labels for reverse proxying. Make sure your Traefik setup is compatible if you plan to use it for routing (e.g., the rules `Host(api.jiten.moe)`, `Host(jiten.moe)`, and `Host(umami.jiten.moe)`).
+
+- **Local Development:**  
+  When developing locally, you might want to adjust URLs in the `.env` file to match your local environment (e.g., `API_BASE_URL=http://localhost:8080/api`).
+
+- **Persistent Storage:**  
+  The Docker Compose file defines persistent volumes (`postgres_data`, `uploads`, and `dictionaries`) to store data across container restarts.
 
 # Parser performance & cache
 Activating the cache can offer an appreciable speedup at the cost of RAM

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Before you begin, make sure you have the following installed on your machine:
 - **Docker Compose:** [Download and install Docker Compose](https://docs.docker.com/compose/install/)
 - **Git:** To clone the repository ([Download Git](https://git-scm.com/downloads))
 
-## Installation Steps
+## Installation Steps - Frontend
 
 ### 1. Clone the Repository
 
@@ -60,6 +60,10 @@ With Docker and Docker Compose installed and the environment variables configure
    - Build and run the API and Web services using their respective Dockerfiles.
    - Pull and run the Postgres and Umami containers.
    - Create and attach the required volumes.
+
+## Installation Steps - CLI
+
+_coming soon™_
 
 ## Services Overview
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
       context: .
       dockerfile: Jiten.Api/Dockerfile
     restart: unless-stopped
+    ports:
+      - "8080:8080"
     depends_on:
       - postgres
     environment:
@@ -33,6 +35,7 @@ services:
       - DictionaryPath=${DICTIONARY_PATH:-/path/to/system_full.dic}
       - JimakuApiKey=${JIMAKU_API_KEY:-}
       - TmdbApiKey=${TMDB_API_KEY:-}
+      - DOTNET_ENVIRONMENT=${DOTNET_ENVIRONMENT:-}
     volumes:
       - ./Shared:/app/Shared:ro
       - uploads:/app/uploads
@@ -48,6 +51,8 @@ services:
       context: .
       dockerfile: Jiten.Web/Dockerfile
     restart: unless-stopped
+    ports:
+      - "3001:3001"
     depends_on:
       - api
     environment:
@@ -61,6 +66,8 @@ services:
   umami:
     image: docker.umami.is/umami-software/umami:postgresql-latest
     restart: unless-stopped
+    ports:
+      - "3005:3005"
     depends_on:
       postgres:
         condition: service_healthy

--- a/postgres-init/create-multiple-databases.sh
+++ b/postgres-init/create-multiple-databases.sh
@@ -7,9 +7,17 @@ function create_user_and_database() {
 	local database=$1
 	echo "Creating user and database '$database'"
 	psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
-	    CREATE USER $database WITH PASSWORD 'umami';
-	    CREATE DATABASE $database;
-	    GRANT ALL PRIVILEGES ON DATABASE $database TO $database;
+	   CREATE USER $database WITH PASSWORD 'umami';
+	   CREATE DATABASE $database;
+	   GRANT ALL PRIVILEGES ON DATABASE $database TO $database;
+
+	   -- Switch to the new database
+	   \c $database
+
+	   -- Ensure the user owns the public schema
+	   ALTER SCHEMA public OWNER TO $database;
+	   GRANT USAGE, CREATE ON SCHEMA public TO $database;
+	   GRANT ALL PRIVILEGES ON SCHEMA public TO $database;
 EOSQL
 }
 
@@ -22,3 +30,4 @@ if [ -n "$POSTGRES_MULTIPLE_DATABASES" ]; then
 	done
 	echo "Multiple databases created"
 fi
+


### PR DESCRIPTION
Summary:
 * Created Installation instructions in `README.md`
 * Adjusted the postgres init files so the user owns the schema (Needed for Umami to run correctly)
 * Made the postgres init files executable so postgres will work upon first launch
 * Added an example `.env` file
 * Passed `DOTNET_ENVIRONMENT=Development` through to the API so locally you can use the Swagger UI
 * Added port mappings for all the relevant containers