### PR TITLE
Add Chinese line filter for .ass subs

### DIFF
--- a/Jiten.Cli/JimakuDownloader.cs
+++ b/Jiten.Cli/JimakuDownloader.cs
@@ -37,7 +37,9 @@ public class JimakuDownloader
         "OPCN",
         "EDCN",
         "SCR",
-        "STAFF"
+        "STAFF",
+        "CHI",
+        "EDSC"
     ];
 
     public static async Task Download(string? baseDirectory, int startRange, int endRange)

--- a/Jiten.Core/Extractors/SubtitleExtractor.cs
+++ b/Jiten.Core/Extractors/SubtitleExtractor.cs
@@ -23,7 +23,9 @@ public partial class SubtitleExtractor
         "OPCN",
         "EDCN",
         "SCR",
-        "STAFF"
+        "STAFF",
+        "CHI",
+        "EDSC"
     ];
 
     /// <summary>


### PR DESCRIPTION
Should fix the problem with subs containing both Japanese and Chinese (e.g. https://jiten.moe/decks/media/125807/detail)
I have not been able to test it, sorry.
It filters out all comments and lines with styles for chinese text. 
Not sure how many entries are affected by this.