### PR TITLE
Add a new difficulty ranking flow based on Dynamic Linear Grouping

### DIFF
--- a/Jiten.Api/Controllers/DifficultyRankingController.cs
+++ b/Jiten.Api/Controllers/DifficultyRankingController.cs
@@ -227,10 +227,11 @@ public class DifficultyRankingController(
                 return Results.BadRequest("Invalid move mode.");
         }
 
-        for (var i = 0; i < groups.Count; i++)
-            groups[i].SortIndex = i;
-
-        await context.SaveChangesAsync();
+        var needsReindex = removedEmptyGroup || request.Mode == DifficultyRankingMoveMode.Insert;
+        if (needsReindex)
+            await SaveGroupsWithReindex(groups);
+        else
+            await context.SaveChangesAsync();
         await SyncDerivedVotes(userId, group);
 
         var result = await GetRankings(group);
@@ -332,6 +333,26 @@ public class DifficultyRankingController(
 
     private Task SyncDerivedVotes(string userId, MediaTypeGroup group)
         => DifficultyRankingSync.SyncDerivedVotes(context, userContext, userId, group);
+
+    private async Task SaveGroupsWithReindex(List<DifficultyRankGroup> groups)
+    {
+        if (groups.Count == 0)
+        {
+            await context.SaveChangesAsync();
+            return;
+        }
+
+        var minIndex = groups.Min(g => g.SortIndex);
+        for (var i = 0; i < groups.Count; i++)
+            groups[i].SortIndex = minIndex - 1 - i;
+
+        await context.SaveChangesAsync();
+
+        for (var i = 0; i < groups.Count; i++)
+            groups[i].SortIndex = i;
+
+        await context.SaveChangesAsync();
+    }
 
     private static DeckSummaryDto MapDeckSummary(int deckId, string title, string? romajiTitle, string? englishTitle, string coverName, float difficulty, MediaType mediaType) => new()
     {

--- a/Jiten.Api/Controllers/DifficultyRankingController.cs
+++ b/Jiten.Api/Controllers/DifficultyRankingController.cs
@@ -297,16 +297,35 @@ public class DifficultyRankingController(
             return;
         }
 
-        var existing = await context.DifficultyVotes
+        var manualPairSet = await context.DifficultyVotes
             .Where(v => v.UserId == userId
+                && v.IsValid
+                && v.Source == DifficultyVoteSource.Manual
+                && rankedDeckIds.Contains(v.DeckLowId)
+                && rankedDeckIds.Contains(v.DeckHighId))
+            .Select(v => new { v.DeckLowId, v.DeckHighId })
+            .ToListAsync();
+        var manualPairs = manualPairSet
+            .Select(v => (v.DeckLowId, v.DeckHighId))
+            .ToHashSet();
+
+        foreach (var pair in manualPairs)
+            implied.Remove(pair);
+
+        var existingWeakOrder = await context.DifficultyVotes
+            .Where(v => v.UserId == userId
+                && v.Source == DifficultyVoteSource.WeakOrder
                 && rankedDeckIds.Contains(v.DeckLowId)
                 && rankedDeckIds.Contains(v.DeckHighId))
             .ToListAsync();
+        existingWeakOrder = existingWeakOrder
+            .Where(v => !manualPairs.Contains((v.DeckLowId, v.DeckHighId)))
+            .ToList();
 
-        var existingPairs = existing.ToDictionary(v => (v.DeckLowId, v.DeckHighId));
+        var existingPairs = existingWeakOrder.ToDictionary(v => (v.DeckLowId, v.DeckHighId));
         var now = DateTimeOffset.UtcNow;
 
-        foreach (var vote in existing)
+        foreach (var vote in existingWeakOrder)
         {
             var rankLow = rankIndexByDeckId[vote.DeckLowId];
             var rankHigh = rankIndexByDeckId[vote.DeckHighId];

--- a/Jiten.Api/Controllers/DifficultyRankingController.cs
+++ b/Jiten.Api/Controllers/DifficultyRankingController.cs
@@ -154,6 +154,11 @@ public class DifficultyRankingController(
             }
         }
 
+        int? sourceIndex = null;
+        var removedEmptyGroup = false;
+        if (currentGroup != null)
+            sourceIndex = groups.IndexOf(currentGroup);
+
         if (currentItem != null)
         {
             currentGroup!.Items.Remove(currentItem);
@@ -162,6 +167,7 @@ public class DifficultyRankingController(
             {
                 context.DifficultyRankGroups.Remove(currentGroup);
                 groups.Remove(currentGroup);
+                removedEmptyGroup = true;
             }
         }
 
@@ -195,6 +201,8 @@ public class DifficultyRankingController(
                     return Results.BadRequest("InsertIndex is required for insert.");
 
                 var insertIndex = Math.Clamp(request.InsertIndex.Value, 0, groups.Count);
+                if (removedEmptyGroup && sourceIndex.HasValue && sourceIndex.Value < insertIndex)
+                    insertIndex = Math.Max(0, insertIndex - 1);
                 var newGroup = new DifficultyRankGroup
                 {
                     UserId = userId,
@@ -322,152 +330,8 @@ public class DifficultyRankingController(
         return true;
     }
 
-    private async Task SyncDerivedVotes(string userId, MediaTypeGroup group)
-    {
-        var completedDeckIds = await userContext.UserDeckPreferences
-            .Where(p => p.UserId == userId && p.Status == DeckStatus.Completed)
-            .Select(p => p.DeckId)
-            .ToListAsync();
-
-        if (completedDeckIds.Count == 0)
-            return;
-
-        var deckRows = await context.Decks.AsNoTracking()
-            .Where(d => completedDeckIds.Contains(d.DeckId) && d.ParentDeckId == null)
-            .Select(d => new { d.DeckId, d.MediaType })
-            .ToListAsync();
-
-        var groups = await context.DifficultyRankGroups
-            .Where(g => g.UserId == userId && g.MediaTypeGroup == group)
-            .Include(g => g.Items)
-            .OrderBy(g => g.SortIndex)
-            .ToListAsync();
-
-        var rankedDeckIds = groups
-            .SelectMany(g => g.Items)
-            .Select(i => i.DeckId)
-            .ToHashSet();
-
-        var groupDeckIds = deckRows
-            .Where(d => MediaTypeGroups.GetGroup(d.MediaType) == group)
-            .Select(d => d.DeckId)
-            .ToHashSet();
-
-        var implied = new Dictionary<(int lowId, int highId), ComparisonOutcome>();
-
-        void AddPair(int deckAId, int deckBId, ComparisonOutcome outcomeForA)
-        {
-            var low = Math.Min(deckAId, deckBId);
-            var high = Math.Max(deckAId, deckBId);
-            var outcome = outcomeForA;
-            if (outcome != ComparisonOutcome.Same && deckAId > deckBId)
-                outcome = (ComparisonOutcome)(-(int)outcome);
-            implied[(low, high)] = outcome;
-        }
-
-        var orderedGroups = groups
-            .Select(g => g.Items.Select(i => i.DeckId).OrderBy(id => id).ToList())
-            .ToList();
-
-        var rankIndexByDeckId = new Dictionary<int, int>();
-        for (var i = 0; i < orderedGroups.Count; i++)
-        {
-            foreach (var id in orderedGroups[i])
-                rankIndexByDeckId[id] = i;
-        }
-
-        foreach (var groupDecks in orderedGroups)
-        {
-            for (var i = 1; i < groupDecks.Count; i++)
-                AddPair(groupDecks[i - 1], groupDecks[i], ComparisonOutcome.Same);
-        }
-
-        for (var i = 0; i + 1 < orderedGroups.Count; i++)
-        {
-            var easierGroup = orderedGroups[i];
-            var harderGroup = orderedGroups[i + 1];
-            foreach (var easier in easierGroup)
-            foreach (var harder in harderGroup)
-                AddPair(easier, harder, ComparisonOutcome.Easier);
-        }
-
-        var staleDerived = await context.DifficultyVotes
-            .Where(v => v.UserId == userId
-                && v.Source == DifficultyVoteSource.WeakOrder
-                && (!rankedDeckIds.Contains(v.DeckLowId) || !rankedDeckIds.Contains(v.DeckHighId))
-                && (groupDeckIds.Contains(v.DeckLowId) || groupDeckIds.Contains(v.DeckHighId)))
-            .ToListAsync();
-        if (staleDerived.Count > 0)
-            context.DifficultyVotes.RemoveRange(staleDerived);
-
-        if (rankedDeckIds.Count < 2)
-        {
-            await context.SaveChangesAsync();
-            return;
-        }
-
-        var manualPairSet = await context.DifficultyVotes
-            .Where(v => v.UserId == userId
-                && v.IsValid
-                && v.Source == DifficultyVoteSource.Manual
-                && rankedDeckIds.Contains(v.DeckLowId)
-                && rankedDeckIds.Contains(v.DeckHighId))
-            .Select(v => new { v.DeckLowId, v.DeckHighId })
-            .ToListAsync();
-        var manualPairs = manualPairSet
-            .Select(v => (v.DeckLowId, v.DeckHighId))
-            .ToHashSet();
-
-        foreach (var pair in manualPairs)
-            implied.Remove(pair);
-
-        var existingWeakOrder = await context.DifficultyVotes
-            .Where(v => v.UserId == userId
-                && v.Source == DifficultyVoteSource.WeakOrder
-                && rankedDeckIds.Contains(v.DeckLowId)
-                && rankedDeckIds.Contains(v.DeckHighId))
-            .ToListAsync();
-        existingWeakOrder = existingWeakOrder
-            .Where(v => !manualPairs.Contains((v.DeckLowId, v.DeckHighId)))
-            .ToList();
-
-        var existingPairs = existingWeakOrder.ToDictionary(v => (v.DeckLowId, v.DeckHighId));
-        var now = DateTimeOffset.UtcNow;
-
-        foreach (var vote in existingWeakOrder)
-        {
-            var rankLow = rankIndexByDeckId[vote.DeckLowId];
-            var rankHigh = rankIndexByDeckId[vote.DeckHighId];
-            var outcome = rankLow == rankHigh
-                ? ComparisonOutcome.Same
-                : rankLow < rankHigh ? ComparisonOutcome.Easier : ComparisonOutcome.Harder;
-
-            if (vote.Outcome != outcome || vote.Source != DifficultyVoteSource.WeakOrder || !vote.IsValid)
-            {
-                vote.Outcome = outcome;
-                vote.Source = DifficultyVoteSource.WeakOrder;
-                vote.IsValid = true;
-                vote.UpdatedAt = now;
-            }
-        }
-
-        foreach (var kvp in implied)
-        {
-            if (existingPairs.ContainsKey(kvp.Key)) continue;
-            context.DifficultyVotes.Add(new DifficultyVote
-            {
-                UserId = userId,
-                DeckLowId = kvp.Key.lowId,
-                DeckHighId = kvp.Key.highId,
-                Outcome = kvp.Value,
-                Source = DifficultyVoteSource.WeakOrder,
-                CreatedAt = now,
-                IsValid = true
-            });
-        }
-
-        await context.SaveChangesAsync();
-    }
+    private Task SyncDerivedVotes(string userId, MediaTypeGroup group)
+        => DifficultyRankingSync.SyncDerivedVotes(context, userContext, userId, group);
 
     private static DeckSummaryDto MapDeckSummary(int deckId, string title, string? romajiTitle, string? englishTitle, string coverName, float difficulty, MediaType mediaType) => new()
     {

--- a/Jiten.Api/Controllers/DifficultyRankingController.cs
+++ b/Jiten.Api/Controllers/DifficultyRankingController.cs
@@ -17,6 +17,11 @@ public class DifficultyRankingController(
     UserDbContext userContext,
     ICurrentUserService currentUserService) : ControllerBase
 {
+    private const decimal AutoRankTieThreshold = 0.25m;
+    private const int AutoRankMinComparisons = 1;
+
+    private sealed record DeckMeta(DeckSummaryDto Summary, MediaTypeGroup Group);
+
     [HttpGet]
     public async Task<IResult> GetRankings([FromQuery] MediaTypeGroup? group = null)
     {
@@ -37,13 +42,24 @@ public class DifficultyRankingController(
             .Select(d => new { d.DeckId, d.OriginalTitle, d.RomajiTitle, d.EnglishTitle, d.CoverName, d.Difficulty, d.MediaType })
             .ToListAsync();
 
-        var deckMap = deckRows.ToDictionary(d => d.DeckId, d => new
-        {
-            Summary = MapDeckSummary(d.DeckId, d.OriginalTitle, d.RomajiTitle, d.EnglishTitle, d.CoverName, d.Difficulty, d.MediaType),
-            Group = MediaTypeGroups.GetGroup(d.MediaType)
-        });
+        var deckMap = deckRows.ToDictionary(
+            d => d.DeckId,
+            d => new DeckMeta(
+                MapDeckSummary(d.DeckId, d.OriginalTitle, d.RomajiTitle, d.EnglishTitle, d.CoverName, d.Difficulty, d.MediaType),
+                MediaTypeGroups.GetGroup(d.MediaType)));
 
         var groupFilter = group.HasValue ? new HashSet<MediaTypeGroup> { group.Value } : null;
+
+        var groupsToInit = deckMap.Values
+            .Select(d => d.Group)
+            .Where(g => groupFilter == null || groupFilter.Contains(g))
+            .Distinct()
+            .ToList();
+        foreach (var g in groupsToInit)
+        {
+            if (await InitializeFromManualVotes(userId, g, deckMap))
+                await SyncDerivedVotes(userId, g);
+        }
 
         var rankGroups = await context.DifficultyRankGroups.AsNoTracking()
             .Where(g => g.UserId == userId && (groupFilter == null || groupFilter.Contains(g.MediaTypeGroup)))
@@ -211,6 +227,99 @@ public class DifficultyRankingController(
 
         var result = await GetRankings(group);
         return result;
+    }
+
+    private async Task<bool> InitializeFromManualVotes(string userId, MediaTypeGroup group, Dictionary<int, DeckMeta> deckMap)
+    {
+        var hasGroups = await context.DifficultyRankGroups
+            .AsNoTracking()
+            .AnyAsync(g => g.UserId == userId && g.MediaTypeGroup == group);
+        if (hasGroups)
+            return false;
+
+        var groupDeckIds = deckMap
+            .Where(kvp => kvp.Value.Group == group)
+            .Select(kvp => kvp.Key)
+            .ToHashSet();
+        if (groupDeckIds.Count < 2)
+            return false;
+
+        var votes = await context.DifficultyVotes.AsNoTracking()
+            .Where(v => v.UserId == userId
+                && v.IsValid
+                && v.Source == DifficultyVoteSource.Manual
+                && groupDeckIds.Contains(v.DeckLowId)
+                && groupDeckIds.Contains(v.DeckHighId))
+            .Select(v => new { v.DeckLowId, v.DeckHighId, v.Outcome })
+            .ToListAsync();
+
+        if (votes.Count == 0)
+            return false;
+
+        var sumByDeck = new Dictionary<int, int>();
+        var countByDeck = new Dictionary<int, int>();
+
+        void AddDelta(int deckId, int delta)
+        {
+            sumByDeck[deckId] = sumByDeck.GetValueOrDefault(deckId) + delta;
+            countByDeck[deckId] = countByDeck.GetValueOrDefault(deckId) + 1;
+        }
+
+        foreach (var v in votes)
+        {
+            var outcome = (int)v.Outcome;
+            AddDelta(v.DeckLowId, outcome);
+            AddDelta(v.DeckHighId, -outcome);
+        }
+
+        var scoredDecks = sumByDeck
+            .Select(kvp => new
+            {
+                DeckId = kvp.Key,
+                Score = kvp.Value / (decimal)countByDeck[kvp.Key],
+                Count = countByDeck[kvp.Key]
+            })
+            .Where(d => d.Count >= AutoRankMinComparisons)
+            .OrderBy(d => d.Score)
+            .ThenBy(d => deckMap[d.DeckId].Summary.Title)
+            .ToList();
+
+        if (scoredDecks.Count < 2)
+            return false;
+
+        var now = DateTimeOffset.UtcNow;
+        var groups = new List<DifficultyRankGroup>();
+        DifficultyRankGroup? current = null;
+        decimal? lastScore = null;
+
+        foreach (var entry in scoredDecks)
+        {
+            if (current == null || (lastScore.HasValue && Math.Abs(entry.Score - lastScore.Value) > AutoRankTieThreshold))
+            {
+                current = new DifficultyRankGroup
+                {
+                    UserId = userId,
+                    MediaTypeGroup = group,
+                    SortIndex = groups.Count,
+                    CreatedAt = now
+                };
+                groups.Add(current);
+            }
+
+            var item = new DifficultyRankItem
+            {
+                UserId = userId,
+                DeckId = entry.DeckId,
+                Group = current,
+                CreatedAt = now
+            };
+            current.Items.Add(item);
+            lastScore = entry.Score;
+        }
+
+        context.DifficultyRankGroups.AddRange(groups);
+        await context.SaveChangesAsync();
+        return true;
     }
 
     private async Task SyncDerivedVotes(string userId, MediaTypeGroup group)

--- a/Jiten.Api/Controllers/DifficultyRankingController.cs
+++ b/Jiten.Api/Controllers/DifficultyRankingController.cs
@@ -86,6 +86,9 @@ public class DifficultyRankingController(
             foreach (var g in groupsForSection)
             {
                 var decks = g.Items
+                    .OrderByDescending(i => i.UpdatedAt)
+                    .ThenByDescending(i => i.CreatedAt)
+                    .ThenBy(i => deckMap[i.DeckId].Summary.Title)
                     .Select(i => deckMap.GetValueOrDefault(i.DeckId))
                     .Where(d => d != null)
                     .Select(d => d!.Summary)
@@ -119,6 +122,7 @@ public class DifficultyRankingController(
         var userId = currentUserService.UserId;
         if (string.IsNullOrEmpty(userId))
             return Results.Unauthorized();
+        var now = DateTimeOffset.UtcNow;
 
         var deck = await context.Decks
             .Where(d => d.DeckId == request.DeckId)
@@ -189,7 +193,8 @@ public class DifficultyRankingController(
                     UserId = userId,
                     DeckId = request.DeckId,
                     Group = target,
-                    CreatedAt = DateTimeOffset.UtcNow
+                    CreatedAt = now,
+                    UpdatedAt = now
                 };
                 target.Items.Add(newItem);
                 context.DifficultyRankItems.Add(newItem);
@@ -208,14 +213,15 @@ public class DifficultyRankingController(
                     UserId = userId,
                     MediaTypeGroup = group,
                     SortIndex = insertIndex,
-                    CreatedAt = DateTimeOffset.UtcNow
+                    CreatedAt = now
                 };
                 var newItem = new DifficultyRankItem
                 {
                     UserId = userId,
                     DeckId = request.DeckId,
                     Group = newGroup,
-                    CreatedAt = DateTimeOffset.UtcNow
+                    CreatedAt = now,
+                    UpdatedAt = now
                 };
                 newGroup.Items.Add(newItem);
                 groups.Insert(insertIndex, newGroup);
@@ -320,7 +326,8 @@ public class DifficultyRankingController(
                 UserId = userId,
                 DeckId = entry.DeckId,
                 Group = current,
-                CreatedAt = now
+                CreatedAt = now,
+                UpdatedAt = now
             };
             current.Items.Add(item);
             lastScore = entry.Score;

--- a/Jiten.Api/Controllers/DifficultyRankingController.cs
+++ b/Jiten.Api/Controllers/DifficultyRankingController.cs
@@ -1,0 +1,354 @@
+using Jiten.Api.Dtos;
+using Jiten.Api.Services;
+using Jiten.Core;
+using Jiten.Core.Data;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace Jiten.Api.Controllers;
+
+[ApiController]
+[Route("api/difficulty-rankings")]
+[Produces("application/json")]
+[Authorize]
+public class DifficultyRankingController(
+    JitenDbContext context,
+    UserDbContext userContext,
+    ICurrentUserService currentUserService) : ControllerBase
+{
+    [HttpGet]
+    public async Task<IResult> GetRankings([FromQuery] MediaTypeGroup? group = null)
+    {
+        var userId = currentUserService.UserId;
+        if (string.IsNullOrEmpty(userId))
+            return Results.Unauthorized();
+
+        var completedDeckIds = await userContext.UserDeckPreferences
+            .Where(p => p.UserId == userId && p.Status == DeckStatus.Completed)
+            .Select(p => p.DeckId)
+            .ToListAsync();
+
+        if (completedDeckIds.Count == 0)
+            return Results.Ok(Array.Empty<DifficultyRankingSectionDto>());
+
+        var deckRows = await context.Decks.AsNoTracking()
+            .Where(d => completedDeckIds.Contains(d.DeckId) && d.ParentDeckId == null)
+            .Select(d => new { d.DeckId, d.OriginalTitle, d.RomajiTitle, d.EnglishTitle, d.CoverName, d.Difficulty, d.MediaType })
+            .ToListAsync();
+
+        var deckMap = deckRows.ToDictionary(d => d.DeckId, d => new
+        {
+            Summary = MapDeckSummary(d.DeckId, d.OriginalTitle, d.RomajiTitle, d.EnglishTitle, d.CoverName, d.Difficulty, d.MediaType),
+            Group = MediaTypeGroups.GetGroup(d.MediaType)
+        });
+
+        var groupFilter = group.HasValue ? new HashSet<MediaTypeGroup> { group.Value } : null;
+
+        var rankGroups = await context.DifficultyRankGroups.AsNoTracking()
+            .Where(g => g.UserId == userId && (groupFilter == null || groupFilter.Contains(g.MediaTypeGroup)))
+            .Include(g => g.Items)
+            .OrderBy(g => g.SortIndex)
+            .ToListAsync();
+
+        var sections = new Dictionary<MediaTypeGroup, DifficultyRankingSectionDto>();
+        foreach (var deckEntry in deckMap.Values)
+        {
+            if (groupFilter != null && !groupFilter.Contains(deckEntry.Group)) continue;
+            if (!sections.ContainsKey(deckEntry.Group))
+                sections[deckEntry.Group] = new DifficultyRankingSectionDto { Group = deckEntry.Group };
+        }
+
+        foreach (var groupEntry in sections.Values)
+        {
+            var groupsForSection = rankGroups
+                .Where(g => g.MediaTypeGroup == groupEntry.Group)
+                .OrderBy(g => g.SortIndex)
+                .ToList();
+
+            var rankedDeckIds = new HashSet<int>();
+            foreach (var g in groupsForSection)
+            {
+                var decks = g.Items
+                    .Select(i => deckMap.GetValueOrDefault(i.DeckId))
+                    .Where(d => d != null)
+                    .Select(d => d!.Summary)
+                    .ToList();
+
+                foreach (var d in decks) rankedDeckIds.Add(d.Id);
+
+                groupEntry.Groups.Add(new DifficultyRankGroupDto
+                {
+                    Id = g.Id,
+                    SortIndex = g.SortIndex,
+                    Decks = decks
+                });
+            }
+
+            var unranked = deckMap.Values
+                .Where(d => d.Group == groupEntry.Group && !rankedDeckIds.Contains(d.Summary.Id))
+                .Select(d => d.Summary)
+                .OrderBy(d => d.Title)
+                .ToList();
+
+            groupEntry.Unranked = unranked;
+        }
+
+        return Results.Ok(sections.Values.OrderBy(s => s.Group).ToList());
+    }
+
+    [HttpPost("move")]
+    public async Task<IResult> Move([FromBody] DifficultyRankingMoveRequest request)
+    {
+        var userId = currentUserService.UserId;
+        if (string.IsNullOrEmpty(userId))
+            return Results.Unauthorized();
+
+        var deck = await context.Decks
+            .Where(d => d.DeckId == request.DeckId)
+            .Select(d => new { d.DeckId, d.MediaType, d.ParentDeckId })
+            .FirstOrDefaultAsync();
+        if (deck == null)
+            return Results.NotFound("Deck not found.");
+        if (deck.ParentDeckId != null)
+            return Results.BadRequest("Difficulty rankings are only available for parent decks, not subdecks.");
+
+        var completed = await userContext.UserDeckPreferences
+            .AnyAsync(p => p.UserId == userId && p.DeckId == request.DeckId && p.Status == DeckStatus.Completed);
+        if (!completed)
+            return Results.Problem("You must have completed this deck to rank it.", statusCode: 403);
+
+        var group = MediaTypeGroups.GetGroup(deck.MediaType);
+
+        var groups = await context.DifficultyRankGroups
+            .Where(g => g.UserId == userId && g.MediaTypeGroup == group)
+            .Include(g => g.Items)
+            .OrderBy(g => g.SortIndex)
+            .ToListAsync();
+
+        DifficultyRankGroup? currentGroup = null;
+        DifficultyRankItem? currentItem = null;
+        foreach (var g in groups)
+        {
+            currentItem = g.Items.FirstOrDefault(i => i.DeckId == request.DeckId);
+            if (currentItem != null)
+            {
+                currentGroup = g;
+                break;
+            }
+        }
+
+        if (currentItem != null)
+        {
+            currentGroup!.Items.Remove(currentItem);
+            context.DifficultyRankItems.Remove(currentItem);
+            if (currentGroup.Items.Count == 0)
+            {
+                context.DifficultyRankGroups.Remove(currentGroup);
+                groups.Remove(currentGroup);
+            }
+        }
+
+        switch (request.Mode)
+        {
+            case DifficultyRankingMoveMode.Unrank:
+                break;
+            case DifficultyRankingMoveMode.Merge:
+            {
+                if (request.TargetGroupId == null)
+                    return Results.BadRequest("TargetGroupId is required for merge.");
+
+                var target = groups.FirstOrDefault(g => g.Id == request.TargetGroupId.Value);
+                if (target == null)
+                    return Results.BadRequest("Target group not found.");
+
+                var newItem = new DifficultyRankItem
+                {
+                    UserId = userId,
+                    DeckId = request.DeckId,
+                    Group = target,
+                    CreatedAt = DateTimeOffset.UtcNow
+                };
+                target.Items.Add(newItem);
+                context.DifficultyRankItems.Add(newItem);
+                break;
+            }
+            case DifficultyRankingMoveMode.Insert:
+            {
+                if (request.InsertIndex == null)
+                    return Results.BadRequest("InsertIndex is required for insert.");
+
+                var insertIndex = Math.Clamp(request.InsertIndex.Value, 0, groups.Count);
+                var newGroup = new DifficultyRankGroup
+                {
+                    UserId = userId,
+                    MediaTypeGroup = group,
+                    SortIndex = insertIndex,
+                    CreatedAt = DateTimeOffset.UtcNow
+                };
+                var newItem = new DifficultyRankItem
+                {
+                    UserId = userId,
+                    DeckId = request.DeckId,
+                    Group = newGroup,
+                    CreatedAt = DateTimeOffset.UtcNow
+                };
+                newGroup.Items.Add(newItem);
+                groups.Insert(insertIndex, newGroup);
+                context.DifficultyRankGroups.Add(newGroup);
+                context.DifficultyRankItems.Add(newItem);
+                break;
+            }
+            default:
+                return Results.BadRequest("Invalid move mode.");
+        }
+
+        for (var i = 0; i < groups.Count; i++)
+            groups[i].SortIndex = i;
+
+        await context.SaveChangesAsync();
+        await SyncDerivedVotes(userId, group);
+
+        var result = await GetRankings(group);
+        return result;
+    }
+
+    private async Task SyncDerivedVotes(string userId, MediaTypeGroup group)
+    {
+        var completedDeckIds = await userContext.UserDeckPreferences
+            .Where(p => p.UserId == userId && p.Status == DeckStatus.Completed)
+            .Select(p => p.DeckId)
+            .ToListAsync();
+
+        if (completedDeckIds.Count == 0)
+            return;
+
+        var deckRows = await context.Decks.AsNoTracking()
+            .Where(d => completedDeckIds.Contains(d.DeckId) && d.ParentDeckId == null)
+            .Select(d => new { d.DeckId, d.MediaType })
+            .ToListAsync();
+
+        var groups = await context.DifficultyRankGroups
+            .Where(g => g.UserId == userId && g.MediaTypeGroup == group)
+            .Include(g => g.Items)
+            .OrderBy(g => g.SortIndex)
+            .ToListAsync();
+
+        var rankedDeckIds = groups
+            .SelectMany(g => g.Items)
+            .Select(i => i.DeckId)
+            .ToHashSet();
+
+        var groupDeckIds = deckRows
+            .Where(d => MediaTypeGroups.GetGroup(d.MediaType) == group)
+            .Select(d => d.DeckId)
+            .ToHashSet();
+
+        var implied = new Dictionary<(int lowId, int highId), ComparisonOutcome>();
+
+        void AddPair(int deckAId, int deckBId, ComparisonOutcome outcomeForA)
+        {
+            var low = Math.Min(deckAId, deckBId);
+            var high = Math.Max(deckAId, deckBId);
+            var outcome = outcomeForA;
+            if (outcome != ComparisonOutcome.Same && deckAId > deckBId)
+                outcome = (ComparisonOutcome)(-(int)outcome);
+            implied[(low, high)] = outcome;
+        }
+
+        var orderedGroups = groups
+            .Select(g => g.Items.Select(i => i.DeckId).OrderBy(id => id).ToList())
+            .ToList();
+
+        var rankIndexByDeckId = new Dictionary<int, int>();
+        for (var i = 0; i < orderedGroups.Count; i++)
+        {
+            foreach (var id in orderedGroups[i])
+                rankIndexByDeckId[id] = i;
+        }
+
+        foreach (var groupDecks in orderedGroups)
+        {
+            for (var i = 1; i < groupDecks.Count; i++)
+                AddPair(groupDecks[i - 1], groupDecks[i], ComparisonOutcome.Same);
+        }
+
+        for (var i = 0; i + 1 < orderedGroups.Count; i++)
+        {
+            var easierGroup = orderedGroups[i];
+            var harderGroup = orderedGroups[i + 1];
+            foreach (var easier in easierGroup)
+            foreach (var harder in harderGroup)
+                AddPair(easier, harder, ComparisonOutcome.Easier);
+        }
+
+        var staleDerived = await context.DifficultyVotes
+            .Where(v => v.UserId == userId
+                && v.Source == DifficultyVoteSource.WeakOrder
+                && (!rankedDeckIds.Contains(v.DeckLowId) || !rankedDeckIds.Contains(v.DeckHighId))
+                && (groupDeckIds.Contains(v.DeckLowId) || groupDeckIds.Contains(v.DeckHighId)))
+            .ToListAsync();
+        if (staleDerived.Count > 0)
+            context.DifficultyVotes.RemoveRange(staleDerived);
+
+        if (rankedDeckIds.Count < 2)
+        {
+            await context.SaveChangesAsync();
+            return;
+        }
+
+        var existing = await context.DifficultyVotes
+            .Where(v => v.UserId == userId
+                && rankedDeckIds.Contains(v.DeckLowId)
+                && rankedDeckIds.Contains(v.DeckHighId))
+            .ToListAsync();
+
+        var existingPairs = existing.ToDictionary(v => (v.DeckLowId, v.DeckHighId));
+        var now = DateTimeOffset.UtcNow;
+
+        foreach (var vote in existing)
+        {
+            var rankLow = rankIndexByDeckId[vote.DeckLowId];
+            var rankHigh = rankIndexByDeckId[vote.DeckHighId];
+            var outcome = rankLow == rankHigh
+                ? ComparisonOutcome.Same
+                : rankLow < rankHigh ? ComparisonOutcome.Easier : ComparisonOutcome.Harder;
+
+            if (vote.Outcome != outcome || vote.Source != DifficultyVoteSource.WeakOrder || !vote.IsValid)
+            {
+                vote.Outcome = outcome;
+                vote.Source = DifficultyVoteSource.WeakOrder;
+                vote.IsValid = true;
+                vote.UpdatedAt = now;
+            }
+        }
+
+        foreach (var kvp in implied)
+        {
+            if (existingPairs.ContainsKey(kvp.Key)) continue;
+            context.DifficultyVotes.Add(new DifficultyVote
+            {
+                UserId = userId,
+                DeckLowId = kvp.Key.lowId,
+                DeckHighId = kvp.Key.highId,
+                Outcome = kvp.Value,
+                Source = DifficultyVoteSource.WeakOrder,
+                CreatedAt = now,
+                IsValid = true
+            });
+        }
+
+        await context.SaveChangesAsync();
+    }
+
+    private static DeckSummaryDto MapDeckSummary(int deckId, string title, string? romajiTitle, string? englishTitle, string coverName, float difficulty, MediaType mediaType) => new()
+    {
+        Id = deckId,
+        Title = title,
+        RomajiTitle = romajiTitle,
+        EnglishTitle = englishTitle,
+        CoverUrl = coverName,
+        Difficulty = difficulty,
+        MediaType = mediaType
+    };
+}

--- a/Jiten.Api/Controllers/DifficultyVoteController.cs
+++ b/Jiten.Api/Controllers/DifficultyVoteController.cs
@@ -33,7 +33,7 @@ public class DifficultyVoteController(
 
         var oneMinuteAgo = DateTimeOffset.UtcNow.AddMinutes(-1);
         var recentTimestamps = await context.DifficultyVotes
-            .Where(v => v.UserId == userId)
+            .Where(v => v.UserId == userId && v.Source == DifficultyVoteSource.Manual)
             .OrderByDescending(v => v.Id)
             .Take(VotesPerMinuteLimit)
             .Select(v => v.CreatedAt)
@@ -466,8 +466,31 @@ public class DifficultyVoteController(
         if (vote == null || vote.UserId != userId)
             return Results.NotFound();
 
+        var wasManual = vote.Source == DifficultyVoteSource.Manual;
+        var deckLowId = vote.DeckLowId;
+        var deckHighId = vote.DeckHighId;
+
         context.DifficultyVotes.Remove(vote);
         await context.SaveChangesAsync();
+
+        if (wasManual)
+        {
+            var decks = await context.Decks.AsNoTracking()
+                .Where(d => d.DeckId == deckLowId || d.DeckId == deckHighId)
+                .Select(d => new { d.DeckId, d.MediaType })
+                .ToListAsync();
+
+            if (decks.Count == 2)
+            {
+                var deckA = decks.First(d => d.DeckId == deckLowId);
+                var deckB = decks.First(d => d.DeckId == deckHighId);
+                var groupA = MediaTypeGroups.GetGroup(deckA.MediaType);
+                var groupB = MediaTypeGroups.GetGroup(deckB.MediaType);
+                if (groupA == groupB)
+                    await DifficultyRankingSync.SyncDerivedVotes(context, userContext, userId, groupA);
+            }
+        }
+
         return Results.NoContent();
     }
 

--- a/Jiten.Api/Controllers/DifficultyVoteController.cs
+++ b/Jiten.Api/Controllers/DifficultyVoteController.cs
@@ -84,6 +84,7 @@ public class DifficultyVoteController(
         {
             existing.Outcome = outcome;
             existing.UpdatedAt = DateTimeOffset.UtcNow;
+            existing.Source = DifficultyVoteSource.Manual;
 
             var existingSkipForUpdate = await context.SkippedComparisons
                 .FirstOrDefaultAsync(s => s.UserId == userId && s.DeckLowId == deckLowId && s.DeckHighId == deckHighId);
@@ -100,6 +101,7 @@ public class DifficultyVoteController(
             DeckLowId = deckLowId,
             DeckHighId = deckHighId,
             Outcome = outcome,
+            Source = DifficultyVoteSource.Manual,
             CreatedAt = DateTimeOffset.UtcNow,
             IsValid = true
         };
@@ -428,7 +430,7 @@ public class DifficultyVoteController(
             default: // "comparisons"
             {
                 var votesQuery = context.DifficultyVotes.AsNoTracking()
-                    .Where(v => v.UserId == userId && v.IsValid)
+                    .Where(v => v.UserId == userId && v.IsValid && v.Source == DifficultyVoteSource.Manual)
                     .OrderByDescending(v => v.Id);
 
                 var totalItems = await votesQuery.CountAsync();
@@ -568,7 +570,7 @@ public class DifficultyVoteController(
             return Results.Unauthorized();
 
         var totalComparisons = await context.DifficultyVotes
-            .CountAsync(v => v.UserId == userId && v.IsValid);
+            .CountAsync(v => v.UserId == userId && v.IsValid && v.Source == DifficultyVoteSource.Manual);
 
         var totalRatings = await context.DifficultyRatings
             .CountAsync(r => r.UserId == userId);
@@ -577,7 +579,7 @@ public class DifficultyVoteController(
         if (totalComparisons > 0)
         {
             var userCounts = context.DifficultyVotes
-                .Where(v => v.IsValid)
+                .Where(v => v.IsValid && v.Source == DifficultyVoteSource.Manual)
                 .GroupBy(v => v.UserId)
                 .Select(g => new { Count = g.Count() });
 

--- a/Jiten.Api/Dtos/DifficultyRankingDtos.cs
+++ b/Jiten.Api/Dtos/DifficultyRankingDtos.cs
@@ -1,0 +1,32 @@
+using Jiten.Core.Data;
+
+namespace Jiten.Api.Dtos;
+
+public enum DifficultyRankingMoveMode
+{
+    Merge = 0,
+    Insert = 1,
+    Unrank = 2
+}
+
+public class DifficultyRankingMoveRequest
+{
+    public int DeckId { get; set; }
+    public DifficultyRankingMoveMode Mode { get; set; }
+    public int? TargetGroupId { get; set; }
+    public int? InsertIndex { get; set; }
+}
+
+public class DifficultyRankGroupDto
+{
+    public int Id { get; set; }
+    public int SortIndex { get; set; }
+    public List<DeckSummaryDto> Decks { get; set; } = [];
+}
+
+public class DifficultyRankingSectionDto
+{
+    public MediaTypeGroup Group { get; set; }
+    public List<DifficultyRankGroupDto> Groups { get; set; } = [];
+    public List<DeckSummaryDto> Unranked { get; set; } = [];
+}

--- a/Jiten.Api/Services/DifficultyRankingSync.cs
+++ b/Jiten.Api/Services/DifficultyRankingSync.cs
@@ -95,6 +95,7 @@ public static class DifficultyRankingSync
         var staleDerived = await context.DifficultyVotes
             .Where(v => v.UserId == userId
                 && v.Source == DifficultyVoteSource.WeakOrder
+                && v.IsValid
                 && (!rankedDeckIds.Contains(v.DeckLowId) || !rankedDeckIds.Contains(v.DeckHighId))
                 && (rankedDeckIdsRaw.Contains(v.DeckLowId) || rankedDeckIdsRaw.Contains(v.DeckHighId)
                     || groupDeckIds.Contains(v.DeckLowId) || groupDeckIds.Contains(v.DeckHighId)))
@@ -123,9 +124,25 @@ public static class DifficultyRankingSync
         foreach (var pair in manualPairs)
             implied.Remove(pair);
 
+        var invalidWeakOrderPairs = await context.DifficultyVotes
+            .Where(v => v.UserId == userId
+                && v.Source == DifficultyVoteSource.WeakOrder
+                && !v.IsValid
+                && rankedDeckIds.Contains(v.DeckLowId)
+                && rankedDeckIds.Contains(v.DeckHighId))
+            .Select(v => new { v.DeckLowId, v.DeckHighId })
+            .ToListAsync();
+        var blockedPairs = invalidWeakOrderPairs
+            .Select(v => (v.DeckLowId, v.DeckHighId))
+            .ToHashSet();
+
+        foreach (var pair in blockedPairs)
+            implied.Remove(pair);
+
         var existingWeakOrder = await context.DifficultyVotes
             .Where(v => v.UserId == userId
                 && v.Source == DifficultyVoteSource.WeakOrder
+                && v.IsValid
                 && rankedDeckIds.Contains(v.DeckLowId)
                 && rankedDeckIds.Contains(v.DeckHighId))
             .ToListAsync();
@@ -144,11 +161,10 @@ public static class DifficultyRankingSync
                 ? ComparisonOutcome.Same
                 : rankLow < rankHigh ? ComparisonOutcome.Easier : ComparisonOutcome.Harder;
 
-            if (vote.Outcome != outcome || vote.Source != DifficultyVoteSource.WeakOrder || !vote.IsValid)
+            if (vote.Outcome != outcome || vote.Source != DifficultyVoteSource.WeakOrder)
             {
                 vote.Outcome = outcome;
                 vote.Source = DifficultyVoteSource.WeakOrder;
-                vote.IsValid = true;
                 vote.UpdatedAt = now;
             }
         }

--- a/Jiten.Api/Services/DifficultyRankingSync.cs
+++ b/Jiten.Api/Services/DifficultyRankingSync.cs
@@ -32,7 +32,7 @@ public static class DifficultyRankingSync
             .OrderBy(g => g.SortIndex)
             .ToListAsync();
 
-        var rankedDeckIds = groups
+        var rankedDeckIdsRaw = groups
             .SelectMany(g => g.Items)
             .Select(i => i.DeckId)
             .ToHashSet();
@@ -40,6 +40,10 @@ public static class DifficultyRankingSync
         var groupDeckIds = deckRows
             .Where(d => MediaTypeGroups.GetGroup(d.MediaType) == group)
             .Select(d => d.DeckId)
+            .ToHashSet();
+
+        var rankedDeckIds = rankedDeckIdsRaw
+            .Where(id => groupDeckIds.Contains(id))
             .ToHashSet();
 
         var implied = new Dictionary<(int lowId, int highId), ComparisonOutcome>();
@@ -55,7 +59,10 @@ public static class DifficultyRankingSync
         }
 
         var orderedGroups = groups
-            .Select(g => g.Items.Select(i => i.DeckId).OrderBy(id => id).ToList())
+            .Select(g => g.Items.Select(i => i.DeckId)
+                .Where(id => groupDeckIds.Contains(id))
+                .OrderBy(id => id)
+                .ToList())
             .Where(list => list.Count > 0)
             .ToList();
 
@@ -89,7 +96,8 @@ public static class DifficultyRankingSync
             .Where(v => v.UserId == userId
                 && v.Source == DifficultyVoteSource.WeakOrder
                 && (!rankedDeckIds.Contains(v.DeckLowId) || !rankedDeckIds.Contains(v.DeckHighId))
-                && (groupDeckIds.Contains(v.DeckLowId) || groupDeckIds.Contains(v.DeckHighId)))
+                && (rankedDeckIdsRaw.Contains(v.DeckLowId) || rankedDeckIdsRaw.Contains(v.DeckHighId)
+                    || groupDeckIds.Contains(v.DeckLowId) || groupDeckIds.Contains(v.DeckHighId)))
             .ToListAsync();
         if (staleDerived.Count > 0)
             context.DifficultyVotes.RemoveRange(staleDerived);

--- a/Jiten.Api/Services/DifficultyRankingSync.cs
+++ b/Jiten.Api/Services/DifficultyRankingSync.cs
@@ -1,0 +1,165 @@
+using System;
+using Jiten.Core;
+using Jiten.Core.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Jiten.Api.Services;
+
+public static class DifficultyRankingSync
+{
+    public static async Task SyncDerivedVotes(
+        JitenDbContext context,
+        UserDbContext userContext,
+        string userId,
+        MediaTypeGroup group)
+    {
+        var completedDeckIds = await userContext.UserDeckPreferences
+            .Where(p => p.UserId == userId && p.Status == DeckStatus.Completed)
+            .Select(p => p.DeckId)
+            .ToListAsync();
+
+        if (completedDeckIds.Count == 0)
+            return;
+
+        var deckRows = await context.Decks.AsNoTracking()
+            .Where(d => completedDeckIds.Contains(d.DeckId) && d.ParentDeckId == null)
+            .Select(d => new { d.DeckId, d.MediaType })
+            .ToListAsync();
+
+        var groups = await context.DifficultyRankGroups
+            .Where(g => g.UserId == userId && g.MediaTypeGroup == group)
+            .Include(g => g.Items)
+            .OrderBy(g => g.SortIndex)
+            .ToListAsync();
+
+        var rankedDeckIds = groups
+            .SelectMany(g => g.Items)
+            .Select(i => i.DeckId)
+            .ToHashSet();
+
+        var groupDeckIds = deckRows
+            .Where(d => MediaTypeGroups.GetGroup(d.MediaType) == group)
+            .Select(d => d.DeckId)
+            .ToHashSet();
+
+        var implied = new Dictionary<(int lowId, int highId), ComparisonOutcome>();
+
+        void AddPair(int deckAId, int deckBId, ComparisonOutcome outcomeForA)
+        {
+            var low = Math.Min(deckAId, deckBId);
+            var high = Math.Max(deckAId, deckBId);
+            var outcome = outcomeForA;
+            if (outcome != ComparisonOutcome.Same && deckAId > deckBId)
+                outcome = (ComparisonOutcome)(-(int)outcome);
+            implied[(low, high)] = outcome;
+        }
+
+        var orderedGroups = groups
+            .Select(g => g.Items.Select(i => i.DeckId).OrderBy(id => id).ToList())
+            .Where(list => list.Count > 0)
+            .ToList();
+
+        var rankIndexByDeckId = new Dictionary<int, int>();
+        for (var i = 0; i < orderedGroups.Count; i++)
+        {
+            foreach (var id in orderedGroups[i])
+                rankIndexByDeckId[id] = i;
+        }
+
+        foreach (var groupDecks in orderedGroups)
+        {
+            for (var i = 0; i < groupDecks.Count; i++)
+            for (var j = i + 1; j < groupDecks.Count; j++)
+                AddPair(groupDecks[i], groupDecks[j], ComparisonOutcome.Same);
+        }
+
+        for (var i = 0; i < orderedGroups.Count; i++)
+        {
+            var easierGroup = orderedGroups[i];
+            for (var j = i + 1; j < orderedGroups.Count; j++)
+            {
+                var harderGroup = orderedGroups[j];
+                foreach (var easier in easierGroup)
+                foreach (var harder in harderGroup)
+                    AddPair(easier, harder, ComparisonOutcome.Easier);
+            }
+        }
+
+        var staleDerived = await context.DifficultyVotes
+            .Where(v => v.UserId == userId
+                && v.Source == DifficultyVoteSource.WeakOrder
+                && (!rankedDeckIds.Contains(v.DeckLowId) || !rankedDeckIds.Contains(v.DeckHighId))
+                && (groupDeckIds.Contains(v.DeckLowId) || groupDeckIds.Contains(v.DeckHighId)))
+            .ToListAsync();
+        if (staleDerived.Count > 0)
+            context.DifficultyVotes.RemoveRange(staleDerived);
+
+        if (rankedDeckIds.Count < 2)
+        {
+            await context.SaveChangesAsync();
+            return;
+        }
+
+        var manualPairSet = await context.DifficultyVotes
+            .Where(v => v.UserId == userId
+                && v.IsValid
+                && v.Source == DifficultyVoteSource.Manual
+                && rankedDeckIds.Contains(v.DeckLowId)
+                && rankedDeckIds.Contains(v.DeckHighId))
+            .Select(v => new { v.DeckLowId, v.DeckHighId })
+            .ToListAsync();
+        var manualPairs = manualPairSet
+            .Select(v => (v.DeckLowId, v.DeckHighId))
+            .ToHashSet();
+
+        foreach (var pair in manualPairs)
+            implied.Remove(pair);
+
+        var existingWeakOrder = await context.DifficultyVotes
+            .Where(v => v.UserId == userId
+                && v.Source == DifficultyVoteSource.WeakOrder
+                && rankedDeckIds.Contains(v.DeckLowId)
+                && rankedDeckIds.Contains(v.DeckHighId))
+            .ToListAsync();
+        existingWeakOrder = existingWeakOrder
+            .Where(v => !manualPairs.Contains((v.DeckLowId, v.DeckHighId)))
+            .ToList();
+
+        var existingPairs = existingWeakOrder.ToDictionary(v => (v.DeckLowId, v.DeckHighId));
+        var now = DateTimeOffset.UtcNow;
+
+        foreach (var vote in existingWeakOrder)
+        {
+            var rankLow = rankIndexByDeckId[vote.DeckLowId];
+            var rankHigh = rankIndexByDeckId[vote.DeckHighId];
+            var outcome = rankLow == rankHigh
+                ? ComparisonOutcome.Same
+                : rankLow < rankHigh ? ComparisonOutcome.Easier : ComparisonOutcome.Harder;
+
+            if (vote.Outcome != outcome || vote.Source != DifficultyVoteSource.WeakOrder || !vote.IsValid)
+            {
+                vote.Outcome = outcome;
+                vote.Source = DifficultyVoteSource.WeakOrder;
+                vote.IsValid = true;
+                vote.UpdatedAt = now;
+            }
+        }
+
+        foreach (var kvp in implied)
+        {
+            if (existingPairs.ContainsKey(kvp.Key)) continue;
+            context.DifficultyVotes.Add(new DifficultyVote
+            {
+                UserId = userId,
+                DeckLowId = kvp.Key.lowId,
+                DeckHighId = kvp.Key.highId,
+                Outcome = kvp.Value,
+                Source = DifficultyVoteSource.WeakOrder,
+                CreatedAt = now,
+                IsValid = true
+            });
+        }
+
+        await context.SaveChangesAsync();
+    }
+}

--- a/Jiten.Core/Data/DifficultyRankGroup.cs
+++ b/Jiten.Core/Data/DifficultyRankGroup.cs
@@ -1,0 +1,12 @@
+namespace Jiten.Core.Data;
+
+public class DifficultyRankGroup
+{
+    public int Id { get; set; }
+    public string UserId { get; set; } = null!;
+    public MediaTypeGroup MediaTypeGroup { get; set; }
+    public int SortIndex { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+
+    public List<DifficultyRankItem> Items { get; set; } = [];
+}

--- a/Jiten.Core/Data/DifficultyRankItem.cs
+++ b/Jiten.Core/Data/DifficultyRankItem.cs
@@ -7,6 +7,7 @@ public class DifficultyRankItem
     public int GroupId { get; set; }
     public int DeckId { get; set; }
     public DateTimeOffset CreatedAt { get; set; }
+    public DateTimeOffset UpdatedAt { get; set; }
 
     public DifficultyRankGroup Group { get; set; } = null!;
     public Deck Deck { get; set; } = null!;

--- a/Jiten.Core/Data/DifficultyRankItem.cs
+++ b/Jiten.Core/Data/DifficultyRankItem.cs
@@ -1,0 +1,13 @@
+namespace Jiten.Core.Data;
+
+public class DifficultyRankItem
+{
+    public int Id { get; set; }
+    public string UserId { get; set; } = null!;
+    public int GroupId { get; set; }
+    public int DeckId { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+
+    public DifficultyRankGroup Group { get; set; } = null!;
+    public Deck Deck { get; set; } = null!;
+}

--- a/Jiten.Core/Data/DifficultyVote.cs
+++ b/Jiten.Core/Data/DifficultyVote.cs
@@ -9,6 +9,12 @@ public enum ComparisonOutcome
     MuchHarder = 2
 }
 
+public enum DifficultyVoteSource
+{
+    Manual = 0,
+    WeakOrder = 1
+}
+
 public class DifficultyVote
 {
     public int Id { get; set; }
@@ -18,6 +24,8 @@ public class DifficultyVote
     public int DeckHighId { get; set; }
 
     public ComparisonOutcome Outcome { get; set; }
+
+    public DifficultyVoteSource Source { get; set; } = DifficultyVoteSource.Manual;
 
     public DateTimeOffset CreatedAt { get; set; }
     public DateTimeOffset? UpdatedAt { get; set; }

--- a/Jiten.Core/Data/MediaTypeGroups.cs
+++ b/Jiten.Core/Data/MediaTypeGroups.cs
@@ -69,7 +69,7 @@ public static class MediaTypeGroups
         return 0m;
     }
 
-    private static MediaTypeGroup GetGroup(MediaType t)
+    public static MediaTypeGroup GetGroup(MediaType t)
     {
         if (Prose.Contains(t)) return MediaTypeGroup.Prose;
         if (VisualText.Contains(t)) return MediaTypeGroup.VisualText;

--- a/Jiten.Core/JitenDbContext.cs
+++ b/Jiten.Core/JitenDbContext.cs
@@ -45,6 +45,8 @@ public class JitenDbContext : DbContext
     public DbSet<DifficultyRating> DifficultyRatings { get; set; }
     public DbSet<SkippedComparison> SkippedComparisons { get; set; }
     public DbSet<BlacklistedComparisonDeck> BlacklistedComparisonDecks { get; set; }
+    public DbSet<DifficultyRankGroup> DifficultyRankGroups { get; set; }
+    public DbSet<DifficultyRankItem> DifficultyRankItems { get; set; }
 
     public DbSet<MediaRequest> MediaRequests { get; set; }
     public DbSet<MediaRequestUpvote> MediaRequestUpvotes { get; set; }
@@ -779,6 +781,7 @@ public class JitenDbContext : DbContext
             entity.Property(e => e.UserId).IsRequired().HasMaxLength(450);
             entity.Property(e => e.CreatedAt).HasDefaultValueSql("CURRENT_TIMESTAMP");
             entity.Property(e => e.IsValid).HasDefaultValue(true);
+            entity.Property(e => e.Source).HasDefaultValue(DifficultyVoteSource.Manual);
 
             entity.HasOne(e => e.DeckLow)
                 .WithMany().HasForeignKey(e => e.DeckLowId).OnDelete(DeleteBehavior.Cascade);
@@ -847,6 +850,45 @@ public class JitenDbContext : DbContext
             entity.HasIndex(e => new { e.UserId, e.DeckId })
                 .IsUnique()
                 .HasDatabaseName("IX_BlacklistedComparisonDecks_UserDeck");
+        });
+
+        modelBuilder.Entity<DifficultyRankGroup>(entity =>
+        {
+            entity.ToTable("DifficultyRankGroups", "jiten");
+            entity.HasKey(e => e.Id);
+
+            entity.Property(e => e.UserId).IsRequired().HasMaxLength(450);
+            entity.Property(e => e.CreatedAt).HasDefaultValueSql("CURRENT_TIMESTAMP");
+
+            entity.HasIndex(e => new { e.UserId, e.MediaTypeGroup, e.SortIndex })
+                .IsUnique()
+                .HasDatabaseName("IX_DifficultyRankGroups_UserGroupSort");
+        });
+
+        modelBuilder.Entity<DifficultyRankItem>(entity =>
+        {
+            entity.ToTable("DifficultyRankItems", "jiten");
+            entity.HasKey(e => e.Id);
+
+            entity.Property(e => e.UserId).IsRequired().HasMaxLength(450);
+            entity.Property(e => e.CreatedAt).HasDefaultValueSql("CURRENT_TIMESTAMP");
+
+            entity.HasOne(e => e.Group)
+                .WithMany(g => g.Items)
+                .HasForeignKey(e => e.GroupId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            entity.HasOne(e => e.Deck)
+                .WithMany()
+                .HasForeignKey(e => e.DeckId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            entity.HasIndex(e => new { e.UserId, e.DeckId })
+                .IsUnique()
+                .HasDatabaseName("IX_DifficultyRankItems_UserDeck");
+
+            entity.HasIndex(e => e.GroupId)
+                .HasDatabaseName("IX_DifficultyRankItems_GroupId");
         });
 
         base.OnModelCreating(modelBuilder);

--- a/Jiten.Core/JitenDbContext.cs
+++ b/Jiten.Core/JitenDbContext.cs
@@ -872,6 +872,7 @@ public class JitenDbContext : DbContext
 
             entity.Property(e => e.UserId).IsRequired().HasMaxLength(450);
             entity.Property(e => e.CreatedAt).HasDefaultValueSql("CURRENT_TIMESTAMP");
+            entity.Property(e => e.UpdatedAt).HasDefaultValueSql("CURRENT_TIMESTAMP");
 
             entity.HasOne(e => e.Group)
                 .WithMany(g => g.Items)

--- a/Jiten.Core/Migrations/20260328120000_AddDifficultyRankings.cs
+++ b/Jiten.Core/Migrations/20260328120000_AddDifficultyRankings.cs
@@ -51,7 +51,8 @@ namespace Jiten.Core.Migrations
                     UserId = table.Column<string>(type: "character varying(450)", maxLength: 450, nullable: false),
                     GroupId = table.Column<int>(type: "integer", nullable: false),
                     DeckId = table.Column<int>(type: "integer", nullable: false),
-                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP")
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP"),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP")
                 },
                 constraints: table =>
                 {

--- a/Jiten.Core/Migrations/20260328120000_AddDifficultyRankings.cs
+++ b/Jiten.Core/Migrations/20260328120000_AddDifficultyRankings.cs
@@ -1,0 +1,119 @@
+using System;
+using Jiten.Core;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Jiten.Core.Migrations
+{
+    [DbContext(typeof(JitenDbContext))]
+    [Migration("20260328120000_AddDifficultyRankings")]
+    /// <inheritdoc />
+    public partial class AddDifficultyRankings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Source",
+                schema: "jiten",
+                table: "DifficultyVotes",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateTable(
+                name: "DifficultyRankGroups",
+                schema: "jiten",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    UserId = table.Column<string>(type: "character varying(450)", maxLength: 450, nullable: false),
+                    MediaTypeGroup = table.Column<int>(type: "integer", nullable: false),
+                    SortIndex = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DifficultyRankGroups", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "DifficultyRankItems",
+                schema: "jiten",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    UserId = table.Column<string>(type: "character varying(450)", maxLength: 450, nullable: false),
+                    GroupId = table.Column<int>(type: "integer", nullable: false),
+                    DeckId = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DifficultyRankItems", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_DifficultyRankItems_Decks_DeckId",
+                        column: x => x.DeckId,
+                        principalSchema: "jiten",
+                        principalTable: "Decks",
+                        principalColumn: "DeckId",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_DifficultyRankItems_DifficultyRankGroups_GroupId",
+                        column: x => x.GroupId,
+                        principalSchema: "jiten",
+                        principalTable: "DifficultyRankGroups",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DifficultyRankGroups_UserGroupSort",
+                schema: "jiten",
+                table: "DifficultyRankGroups",
+                columns: new[] { "UserId", "MediaTypeGroup", "SortIndex" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DifficultyRankItems_DeckId",
+                schema: "jiten",
+                table: "DifficultyRankItems",
+                column: "DeckId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DifficultyRankItems_GroupId",
+                schema: "jiten",
+                table: "DifficultyRankItems",
+                column: "GroupId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DifficultyRankItems_UserDeck",
+                schema: "jiten",
+                table: "DifficultyRankItems",
+                columns: new[] { "UserId", "DeckId" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "DifficultyRankItems",
+                schema: "jiten");
+
+            migrationBuilder.DropTable(
+                name: "DifficultyRankGroups",
+                schema: "jiten");
+
+            migrationBuilder.DropColumn(
+                name: "Source",
+                schema: "jiten",
+                table: "DifficultyVotes");
+        }
+    }
+}

--- a/Jiten.Core/Migrations/JitenDbContextModelSnapshot.cs
+++ b/Jiten.Core/Migrations/JitenDbContextModelSnapshot.cs
@@ -568,6 +568,11 @@ namespace Jiten.Core.Migrations
                         .HasMaxLength(450)
                         .HasColumnType("character varying(450)");
 
+                    b.Property<DateTimeOffset>("UpdatedAt")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("timestamp with time zone")
+                        .HasDefaultValueSql("CURRENT_TIMESTAMP");
+
                     b.HasKey("Id");
 
                     b.HasIndex("DeckId");

--- a/Jiten.Core/Migrations/JitenDbContextModelSnapshot.cs
+++ b/Jiten.Core/Migrations/JitenDbContextModelSnapshot.cs
@@ -479,6 +479,11 @@ namespace Jiten.Core.Migrations
                     b.Property<int>("Outcome")
                         .HasColumnType("integer");
 
+                    b.Property<int>("Source")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("integer")
+                        .HasDefaultValue(0);
+
                     b.Property<DateTimeOffset?>("UpdatedAt")
                         .HasColumnType("timestamp with time zone");
 
@@ -504,6 +509,77 @@ namespace Jiten.Core.Migrations
                         .HasFilter("\"IsValid\" = true");
 
                     b.ToTable("DifficultyVotes", "jiten");
+                });
+
+            modelBuilder.Entity("Jiten.Core.Data.DifficultyRankGroup", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("integer");
+
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
+
+                    b.Property<DateTimeOffset>("CreatedAt")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("timestamp with time zone")
+                        .HasDefaultValueSql("CURRENT_TIMESTAMP");
+
+                    b.Property<int>("MediaTypeGroup")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("SortIndex")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("UserId")
+                        .IsRequired()
+                        .HasMaxLength(450)
+                        .HasColumnType("character varying(450)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("UserId", "MediaTypeGroup", "SortIndex")
+                        .IsUnique()
+                        .HasDatabaseName("IX_DifficultyRankGroups_UserGroupSort");
+
+                    b.ToTable("DifficultyRankGroups", "jiten");
+                });
+
+            modelBuilder.Entity("Jiten.Core.Data.DifficultyRankItem", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("integer");
+
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
+
+                    b.Property<DateTimeOffset>("CreatedAt")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("timestamp with time zone")
+                        .HasDefaultValueSql("CURRENT_TIMESTAMP");
+
+                    b.Property<int>("DeckId")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("GroupId")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("UserId")
+                        .IsRequired()
+                        .HasMaxLength(450)
+                        .HasColumnType("character varying(450)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("DeckId");
+
+                    b.HasIndex("GroupId")
+                        .HasDatabaseName("IX_DifficultyRankItems_GroupId");
+
+                    b.HasIndex("UserId", "DeckId")
+                        .IsUnique()
+                        .HasDatabaseName("IX_DifficultyRankItems_UserDeck");
+
+                    b.ToTable("DifficultyRankItems", "jiten");
                 });
 
             modelBuilder.Entity("Jiten.Core.Data.ExampleSentence", b =>
@@ -1552,6 +1628,30 @@ namespace Jiten.Core.Migrations
                     b.Navigation("DeckHigh");
 
                     b.Navigation("DeckLow");
+                });
+
+            modelBuilder.Entity("Jiten.Core.Data.DifficultyRankItem", b =>
+                {
+                    b.HasOne("Jiten.Core.Data.Deck", "Deck")
+                        .WithMany()
+                        .HasForeignKey("DeckId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("Jiten.Core.Data.DifficultyRankGroup", "Group")
+                        .WithMany("Items")
+                        .HasForeignKey("GroupId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Deck");
+
+                    b.Navigation("Group");
+                });
+
+            modelBuilder.Entity("Jiten.Core.Data.DifficultyRankGroup", b =>
+                {
+                    b.Navigation("Items");
                 });
 
             modelBuilder.Entity("Jiten.Core.Data.ExampleSentence", b =>

--- a/Jiten.Tests/Integration/DifficultyVoteTests.cs
+++ b/Jiten.Tests/Integration/DifficultyVoteTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using FluentAssertions;
+using Jiten.Api.Dtos;
 using Jiten.Api.Jobs;
 using Jiten.Core;
 using Jiten.Core.Data;
@@ -196,6 +197,65 @@ public class DifficultyVoteTests(JitenWebApplicationFactory factory)
             .WithJsonContent(new { deckAId = 1, deckBId = 3, outcome = (int)ComparisonOutcome.Easier });
         var response = await _client.SendAsync(request);
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task RankingMove_ReaddingDeckToGroup_PutsItAtTop()
+    {
+        await SeedTestData();
+
+        int rankGroupId;
+        using (var scope = factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<JitenDbContext>();
+            var group = new DifficultyRankGroup
+            {
+                UserId = TestUsers.UserA,
+                MediaTypeGroup = MediaTypeGroup.AudioVisual,
+                SortIndex = 0,
+                CreatedAt = DateTimeOffset.UtcNow.AddDays(-10)
+            };
+            db.DifficultyRankGroups.Add(group);
+            await db.SaveChangesAsync();
+
+            rankGroupId = group.Id;
+            db.DifficultyRankItems.AddRange(
+                new DifficultyRankItem
+                {
+                    UserId = TestUsers.UserA,
+                    GroupId = rankGroupId,
+                    DeckId = 1,
+                    CreatedAt = DateTimeOffset.UtcNow.AddDays(-10),
+                    UpdatedAt = DateTimeOffset.UtcNow.AddDays(-10)
+                },
+                new DifficultyRankItem
+                {
+                    UserId = TestUsers.UserA,
+                    GroupId = rankGroupId,
+                    DeckId = 2,
+                    CreatedAt = DateTimeOffset.UtcNow.AddDays(-5),
+                    UpdatedAt = DateTimeOffset.UtcNow.AddDays(-5)
+                });
+            await db.SaveChangesAsync();
+        }
+
+        var unrankRequest = new HttpRequestMessage(HttpMethod.Post, "/api/difficulty-rankings/move")
+            .WithUser(TestUsers.UserA)
+            .WithJsonContent(new { deckId = 1, mode = (int)DifficultyRankingMoveMode.Unrank });
+        var unrankResponse = await _client.SendAsync(unrankRequest);
+        unrankResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var mergeRequest = new HttpRequestMessage(HttpMethod.Post, "/api/difficulty-rankings/move")
+            .WithUser(TestUsers.UserA)
+            .WithJsonContent(new { deckId = 1, mode = (int)DifficultyRankingMoveMode.Merge, targetGroupId = rankGroupId });
+        var mergeResponse = await _client.SendAsync(mergeRequest);
+        mergeResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await mergeResponse.Content.ReadFromJsonAsync<JsonElement>();
+        var audioVisualSection = body.EnumerateArray().First(s => s.GetProperty("group").GetInt32() == (int)MediaTypeGroup.AudioVisual);
+        var firstGroup = audioVisualSection.GetProperty("groups")[0];
+        var firstDeckId = firstGroup.GetProperty("decks")[0].GetProperty("id").GetInt32();
+        firstDeckId.Should().Be(1);
     }
 
     [Fact]

--- a/Jiten.Web/app/composables/useDifficultyRankings.ts
+++ b/Jiten.Web/app/composables/useDifficultyRankings.ts
@@ -1,0 +1,43 @@
+import type { DifficultyRankingSectionDto } from '~/types/types';
+import { DifficultyRankingMoveMode, type MediaTypeGroup } from '~/types';
+
+export function useDifficultyRankings() {
+  const { $api } = useNuxtApp();
+  const error = ref<Error | null>(null);
+
+  const fetchRankings = async (group?: MediaTypeGroup): Promise<DifficultyRankingSectionDto[]> => {
+    error.value = null;
+    try {
+      return await $api<DifficultyRankingSectionDto[]>('difficulty-rankings', {
+        query: group !== undefined ? { group } : undefined,
+      }) ?? [];
+    } catch (e) {
+      error.value = e as Error;
+      return [];
+    }
+  };
+
+  const moveRanking = async (params: {
+    deckId: number;
+    mode: DifficultyRankingMoveMode;
+    targetGroupId?: number;
+    insertIndex?: number;
+  }): Promise<DifficultyRankingSectionDto[]> => {
+    error.value = null;
+    try {
+      return await $api<DifficultyRankingSectionDto[]>('difficulty-rankings/move', {
+        method: 'POST',
+        body: params,
+      }) ?? [];
+    } catch (e) {
+      error.value = e as Error;
+      return [];
+    }
+  };
+
+  return {
+    error,
+    fetchRankings,
+    moveRanking,
+  };
+}

--- a/Jiten.Web/app/pages/ratings/index.vue
+++ b/Jiten.Web/app/pages/ratings/index.vue
@@ -270,6 +270,9 @@ onMounted(async () => {
         <p class="text-muted-color text-sm mt-1">
           Help improve difficulty ratings by comparing pairs of media you have completed.
         </p>
+        <NuxtLink to="/ratings/ranking" class="text-sm text-muted-color hover:text-primary-500">
+          Try the new ranking flow
+        </NuxtLink>
       </div>
       <div v-if="stats" class="flex items-center gap-4">
         <div class="text-center">

--- a/Jiten.Web/app/pages/ratings/ranking.vue
+++ b/Jiten.Web/app/pages/ratings/ranking.vue
@@ -293,7 +293,7 @@ onUnmounted(cancelDrag);
                     <div class="text-xs uppercase tracking-wide text-muted-color">Rank {{ index + 1 }}</div>
                     <div class="text-xs text-muted-color">{{ group.decks.length }}</div>
                   </div>
-                  <div class="flex flex-col gap-2">
+                  <div class="rank-group-list flex flex-col gap-2">
                     <div
                       v-for="deck in group.decks"
                       :key="deck.id"
@@ -323,6 +323,28 @@ onUnmounted(cancelDrag);
 </template>
 
 <style scoped>
+.rank-group-list {
+  --rank-pill-height: 58px;
+  max-height: calc(var(--rank-pill-height) * 3 + 1rem);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding-right: 0.25rem;
+  scrollbar-gutter: stable;
+}
+
+.rank-group-list::-webkit-scrollbar {
+  width: 8px;
+}
+
+.rank-group-list::-webkit-scrollbar-thumb {
+  background: var(--surface-300);
+  border-radius: 999px;
+}
+
+.rank-group-list::-webkit-scrollbar-track {
+  background: transparent;
+}
+
 .deck-pill {
   display: flex;
   align-items: center;

--- a/Jiten.Web/app/pages/ratings/ranking.vue
+++ b/Jiten.Web/app/pages/ratings/ranking.vue
@@ -1,0 +1,384 @@
+<script setup lang="ts">
+import type { DeckSummaryDto, DifficultyRankingSectionDto } from '~/types/types';
+import { DifficultyRankingMoveMode, MediaTypeGroup, TitleLanguage } from '~/types';
+import { getMediaTypeGroupText } from '~/utils/mediaTypeMapper';
+
+definePageMeta({
+  middleware: ['auth'],
+});
+
+useHead({ title: 'Rank Difficulties - Jiten' });
+
+const { fetchRankings, moveRanking } = useDifficultyRankings();
+const jitenStore = useJitenStore();
+
+const sections = ref<DifficultyRankingSectionDto[]>([]);
+const activeGroup = ref<MediaTypeGroup | null>(null);
+const isLoading = ref(true);
+const isUpdating = ref(false);
+
+const draggingDeck = ref<DeckSummaryDto | null>(null);
+const draggingFromGroupId = ref<number | null>(null);
+const dragOver = ref<{ kind: 'group'; groupId: number } | { kind: 'gap'; index: number } | { kind: 'unranked' } | null>(null);
+
+let ghost: HTMLElement | null = null;
+let offsetX = 0;
+let offsetY = 0;
+
+function deckTitle(deck: DeckSummaryDto): string {
+  if (jitenStore.titleLanguage === TitleLanguage.English)
+    return deck.englishTitle ?? deck.romajiTitle ?? deck.title;
+  if (jitenStore.titleLanguage === TitleLanguage.Romaji)
+    return deck.romajiTitle ?? deck.title;
+  return deck.title;
+}
+
+const activeSection = computed(() => {
+  if (activeGroup.value === null) return null;
+  return sections.value.find(s => s.group === activeGroup.value) ?? null;
+});
+
+function ensureActiveGroup() {
+  if (sections.value.length === 0) {
+    activeGroup.value = null;
+    return;
+  }
+  if (activeGroup.value === null || !sections.value.some(s => s.group === activeGroup.value)) {
+    activeGroup.value = sections.value[0].group;
+  }
+}
+
+async function loadRankings() {
+  isLoading.value = true;
+  sections.value = await fetchRankings();
+  ensureActiveGroup();
+  isLoading.value = false;
+}
+
+function mergeSections(updated: DifficultyRankingSectionDto[]) {
+  for (const section of updated) {
+    const idx = sections.value.findIndex(s => s.group === section.group);
+    if (idx >= 0) sections.value[idx] = section;
+    else sections.value.push(section);
+  }
+  sections.value = sections.value.sort((a, b) => a.group - b.group);
+  ensureActiveGroup();
+}
+
+function cancelDrag() {
+  document.removeEventListener('pointermove', onPointerMove);
+  document.removeEventListener('pointerup', onPointerUp);
+  document.removeEventListener('pointercancel', onPointerUp);
+  window.removeEventListener('blur', cancelDrag);
+
+  if (ghost) {
+    ghost.remove();
+    ghost = null;
+  }
+
+  draggingDeck.value = null;
+  draggingFromGroupId.value = null;
+  dragOver.value = null;
+}
+
+function onPointerDown(deck: DeckSummaryDto, fromGroupId: number | null, ev: PointerEvent) {
+  if (ev.button !== 0) return;
+  ev.preventDefault();
+
+  draggingDeck.value = deck;
+  draggingFromGroupId.value = fromGroupId;
+
+  const target = ev.currentTarget as HTMLElement | null;
+  if (!target) return;
+
+  const rect = target.getBoundingClientRect();
+  offsetX = ev.clientX - rect.left;
+  offsetY = ev.clientY - rect.top;
+
+  const clone = target.cloneNode(true) as HTMLElement;
+  clone.style.position = 'fixed';
+  clone.style.left = `${rect.left}px`;
+  clone.style.top = `${rect.top}px`;
+  clone.style.width = `${rect.width}px`;
+  clone.style.zIndex = '9999';
+  clone.style.pointerEvents = 'none';
+  clone.style.opacity = '0.9';
+  clone.style.boxShadow = '0 10px 24px rgba(0,0,0,0.25)';
+  clone.style.transform = 'scale(1.02)';
+  document.body.appendChild(clone);
+  ghost = clone;
+
+  document.addEventListener('pointermove', onPointerMove);
+  document.addEventListener('pointerup', onPointerUp);
+  document.addEventListener('pointercancel', onPointerUp);
+  window.addEventListener('blur', cancelDrag);
+}
+
+function updateDropTarget(ev: PointerEvent) {
+  const el = document.elementFromPoint(ev.clientX, ev.clientY) as HTMLElement | null;
+  if (!el) {
+    dragOver.value = null;
+    return;
+  }
+
+  const unrankedEl = el.closest('[data-drop-unranked]');
+  if (unrankedEl) {
+    dragOver.value = { kind: 'unranked' };
+    return;
+  }
+
+  const groupEl = el.closest('[data-drop-group]') as HTMLElement | null;
+  if (groupEl?.dataset.dropGroup) {
+    dragOver.value = { kind: 'group', groupId: Number(groupEl.dataset.dropGroup) };
+    return;
+  }
+
+  const gapEl = el.closest('[data-drop-gap]') as HTMLElement | null;
+  if (gapEl?.dataset.dropGap) {
+    dragOver.value = { kind: 'gap', index: Number(gapEl.dataset.dropGap) };
+    return;
+  }
+
+  dragOver.value = null;
+}
+
+function onPointerMove(ev: PointerEvent) {
+  if (!ghost) return;
+  ev.preventDefault();
+  ghost.style.left = `${ev.clientX - offsetX}px`;
+  ghost.style.top = `${ev.clientY - offsetY}px`;
+  updateDropTarget(ev);
+}
+
+async function applyMove(params: { deckId: number; mode: DifficultyRankingMoveMode; targetGroupId?: number; insertIndex?: number }) {
+  if (isUpdating.value) return;
+  isUpdating.value = true;
+  const updated = await moveRanking(params);
+  if (updated.length > 0) mergeSections(updated);
+  isUpdating.value = false;
+}
+
+async function handleDrop() {
+  if (!draggingDeck.value || !dragOver.value) return;
+  if (!activeSection.value) return;
+
+  const deckId = draggingDeck.value.id;
+
+  if (dragOver.value.kind === 'unranked') {
+    if (draggingFromGroupId.value == null) return;
+    await applyMove({ deckId, mode: DifficultyRankingMoveMode.Unrank });
+    return;
+  }
+
+  if (dragOver.value.kind === 'group') {
+    if (dragOver.value.groupId === draggingFromGroupId.value) return;
+    await applyMove({
+      deckId,
+      mode: DifficultyRankingMoveMode.Merge,
+      targetGroupId: dragOver.value.groupId,
+    });
+    return;
+  }
+
+  if (dragOver.value.kind === 'gap') {
+    await applyMove({
+      deckId,
+      mode: DifficultyRankingMoveMode.Insert,
+      insertIndex: dragOver.value.index,
+    });
+  }
+}
+
+async function onPointerUp() {
+  await handleDrop();
+  cancelDrag();
+}
+
+onMounted(loadRankings);
+onUnmounted(cancelDrag);
+</script>
+
+<template>
+  <div class="p-2 md:p-4 overflow-hidden">
+    <div class="flex flex-col md:flex-row items-start md:items-center justify-between mb-6 gap-3">
+      <div>
+        <h1 class="text-2xl font-bold">Rank Difficulties</h1>
+        <p class="text-muted-color text-sm mt-1">
+          Drag titles into order. Drop between groups to create a new rank, or stack to mark a tie.
+        </p>
+      </div>
+      <NuxtLink to="/ratings" class="text-sm text-muted-color hover:text-primary-500">
+        Back to comparisons
+      </NuxtLink>
+    </div>
+
+    <div v-if="isLoading" class="flex justify-center py-12">
+      <ProgressSpinner style="width: 50px; height: 50px" />
+    </div>
+
+    <div v-else-if="sections.length === 0" class="text-center text-muted-color py-12">
+      Complete at least two titles to start ranking.
+    </div>
+
+    <div v-else>
+      <div class="flex flex-wrap gap-2 mb-4">
+        <Button
+          v-for="section in sections"
+          :key="section.group"
+          :label="getMediaTypeGroupText(section.group)"
+          size="small"
+          :severity="section.group === activeGroup ? 'primary' : 'secondary'"
+          @click="activeGroup = section.group"
+        />
+      </div>
+
+      <div v-if="activeSection" class="grid grid-cols-1 lg:grid-cols-[minmax(0,340px)_1fr] gap-4">
+        <!-- Unranked -->
+        <Card class="min-w-0" data-drop-unranked :class="{ 'is-drop-active': dragOver?.kind === 'unranked' }">
+          <template #content>
+            <div class="flex items-center justify-between mb-3">
+              <div class="font-semibold">Unranked</div>
+              <div class="text-xs text-muted-color">{{ activeSection.unranked.length }}</div>
+            </div>
+            <div v-if="activeSection.unranked.length === 0" class="text-sm text-muted-color">
+              Everything in this group is ranked.
+            </div>
+            <div v-else class="flex flex-col gap-2">
+              <div
+                v-for="deck in activeSection.unranked"
+                :key="deck.id"
+                class="deck-pill"
+                @pointerdown="onPointerDown(deck, null, $event)"
+              >
+                <img :src="deck.coverUrl || '/img/nocover.jpg'" :alt="deckTitle(deck)" class="h-10 w-7 rounded object-cover" />
+                <div class="flex-1 min-w-0">
+                  <div class="truncate text-sm font-medium">{{ deckTitle(deck) }}</div>
+                </div>
+              </div>
+            </div>
+          </template>
+        </Card>
+
+        <!-- Ranked groups -->
+        <div class="min-w-0">
+          <div
+            v-if="activeSection.groups.length === 0"
+            class="empty-drop text-muted-color"
+            :class="{ 'is-active': dragOver?.kind === 'gap' && dragOver.index === 0 }"
+            :data-drop-gap="0"
+          >
+            Drop here to create the first rank.
+          </div>
+
+          <div v-else class="flex flex-col gap-3">
+            <div
+              v-for="(group, index) in activeSection.groups"
+              :key="group.id"
+              class="flex flex-col gap-3"
+            >
+              <div
+                class="drop-gap"
+                :class="{ 'is-active': dragOver?.kind === 'gap' && dragOver.index === index }"
+                :data-drop-gap="index"
+              />
+
+              <Card
+                class="rank-group min-w-0"
+                :class="{ 'is-active': dragOver?.kind === 'group' && dragOver.groupId === group.id }"
+                :data-drop-group="group.id"
+              >
+                <template #content>
+                  <div class="flex items-center justify-between mb-2">
+                    <div class="text-xs uppercase tracking-wide text-muted-color">Rank {{ index + 1 }}</div>
+                    <div class="text-xs text-muted-color">{{ group.decks.length }}</div>
+                  </div>
+                  <div class="flex flex-col gap-2">
+                    <div
+                      v-for="deck in group.decks"
+                      :key="deck.id"
+                      class="deck-pill"
+                      @pointerdown="onPointerDown(deck, group.id, $event)"
+                    >
+                      <img :src="deck.coverUrl || '/img/nocover.jpg'" :alt="deckTitle(deck)" class="h-10 w-7 rounded object-cover" />
+                      <div class="flex-1 min-w-0">
+                        <div class="truncate text-sm font-medium">{{ deckTitle(deck) }}</div>
+                      </div>
+                    </div>
+                  </div>
+                </template>
+              </Card>
+            </div>
+
+            <div
+              class="drop-gap"
+              :class="{ 'is-active': dragOver?.kind === 'gap' && dragOver.index === activeSection.groups.length }"
+              :data-drop-gap="activeSection.groups.length"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.deck-pill {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  border: 1px solid var(--surface-200);
+  border-radius: 0.5rem;
+  background: var(--surface-0);
+  cursor: grab;
+  transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.deck-pill:hover {
+  border-color: var(--primary-300);
+  background: var(--surface-50);
+}
+
+.rank-group.is-active,
+.deck-pill.is-active {
+  border-color: var(--primary-400);
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.15);
+}
+
+.drop-gap {
+  height: 12px;
+  border-radius: 999px;
+  background: transparent;
+  border: 1px dashed transparent;
+  transition: all 0.2s ease;
+}
+
+.drop-gap.is-active {
+  height: 18px;
+  border-color: var(--primary-400);
+  background: rgba(59, 130, 246, 0.08);
+}
+
+.empty-drop {
+  border: 1px dashed var(--surface-300);
+  border-radius: 0.75rem;
+  padding: 2rem;
+  text-align: center;
+}
+
+.empty-drop.is-active {
+  border-color: var(--primary-400);
+  background: rgba(59, 130, 246, 0.08);
+}
+
+:deep(.is-drop-active .p-card-body) {
+  border: 1px solid var(--primary-300);
+  border-radius: 0.75rem;
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.12);
+}
+
+:deep(.rank-group .p-card-body),
+:deep(.rank-group .p-card-content) {
+  padding: 0.75rem;
+}
+</style>

--- a/Jiten.Web/app/pages/ratings/ranking.vue
+++ b/Jiten.Web/app/pages/ratings/ranking.vue
@@ -261,6 +261,7 @@ onUnmounted(cancelDrag);
 
         <!-- Ranked groups -->
         <div class="min-w-0">
+          <div class="text-xs text-muted-color mb-2">Top is easiest, bottom is hardest.</div>
           <div
             v-if="activeSection.groups.length === 0"
             class="empty-drop text-muted-color"

--- a/Jiten.Web/app/types/enums.ts
+++ b/Jiten.Web/app/types/enums.ts
@@ -11,6 +11,20 @@ export enum MediaType {
   Audio = 10,
 }
 
+export enum MediaTypeGroup {
+  Prose = 0,
+  VisualText = 1,
+  AudioVisual = 2,
+  NonFiction = 3,
+  Unknown = 4,
+}
+
+export enum DifficultyRankingMoveMode {
+  Merge = 0,
+  Insert = 1,
+  Unrank = 2,
+}
+
 export enum LinkType {
   Web = 1,
   Vndb = 2,

--- a/Jiten.Web/app/types/types.ts
+++ b/Jiten.Web/app/types/types.ts
@@ -1,4 +1,4 @@
-import { type ComparisonOutcome, type DeckRelationshipType, type DeckStatus, type FsrsRating, type FsrsState, type Genre, type KnownState, type LinkType, type MediaType, type NotificationType, type ReadingType, type RequestAction, type RequestStatus, type WordSetStateType } from '~/types';
+import { type ComparisonOutcome, type DeckRelationshipType, type DeckStatus, type FsrsRating, type FsrsState, type Genre, type KnownState, type LinkType, type MediaType, type MediaTypeGroup, type NotificationType, type ReadingType, type RequestAction, type RequestStatus, type WordSetStateType } from '~/types';
 
 export interface Deck {
   deckId: number;
@@ -711,6 +711,18 @@ export interface BlacklistedDeckDto {
   coverUrl: string | null
   mediaType: MediaType
   createdAt: string
+}
+
+export interface DifficultyRankGroupDto {
+  id: number
+  sortIndex: number
+  decks: DeckSummaryDto[]
+}
+
+export interface DifficultyRankingSectionDto {
+  group: MediaTypeGroup
+  groups: DifficultyRankGroupDto[]
+  unranked: DeckSummaryDto[]
 }
 
 // SRS Study types

--- a/Jiten.Web/app/utils/mediaTypeMapper.ts
+++ b/Jiten.Web/app/utils/mediaTypeMapper.ts
@@ -1,4 +1,4 @@
-import { MediaType } from '~/types';
+import { MediaType, MediaTypeGroup } from '~/types';
 
 export function getMediaTypeText(mediaType: MediaType): string {
   switch (mediaType) {
@@ -49,6 +49,21 @@ export function getChildrenCountText(mediaType: MediaType): string {
       return 'Chapters';
     case MediaType.Audio:
       return 'Entries';
+    default:
+      return 'Unknown';
+  }
+}
+
+export function getMediaTypeGroupText(group: MediaTypeGroup): string {
+  switch (group) {
+    case MediaTypeGroup.Prose:
+      return 'Prose';
+    case MediaTypeGroup.VisualText:
+      return 'Visual Text';
+    case MediaTypeGroup.AudioVisual:
+      return 'Audio Visual';
+    case MediaTypeGroup.NonFiction:
+      return 'Non-Fiction';
     default:
       return 'Unknown';
   }


### PR DESCRIPTION
This PR adds a ranking-based difficulty workflow alongside the existing pairwise comparison flow. Users can now open a dedicated /ratings/ranking page, see their completed parent decks grouped by media type, and drag titles into ordered tiers or merge them into the same tier to mark ties.

  On the backend, rankings are persisted through new DifficultyRankGroups and DifficultyRankItems models and exposed via api/difficulty-rankings. Existing manual comparison votes can bootstrap an initial ranking, and saved rankings are synchronized back into derived weak-order votes so the broader difficulty system can benefit from the ordering without mixing generated data into manual vote history, rate limits, or user stats. This also includes the frontend composable/types needed for the new flow, a link from the current ratings page, and the supporting EF migration.

https://discord.com/channels/1352716079734198362/1487334332598059108