### PR TITLE
Added example sentences media filter for SRS study cards

### DIFF
--- a/Jiten.Api/Controllers/StudyController.cs
+++ b/Jiten.Api/Controllers/StudyController.cs
@@ -2686,6 +2686,9 @@ public class StudyController(
             .ToListAsync();
         var studyDeckIdArray = studyDecks.Where(sd => sd.DeckId.HasValue).Select(sd => sd.DeckId!.Value).ToArray();
 
+        var settings = await LoadStudySettings(userId);
+        var mediaTypeFilter = settings.ExampleSentenceMediaTypes is { Count: > 0 } mt ? mt.ToArray() : null;
+
         var pairWordIds = request.Pairs.Select(p => p.WordId).ToArray();
         var pairReadingIndexes = request.Pairs.Select(p => (short)p.ReadingIndex).ToArray();
         var wordIds = pairWordIds.Distinct().ToList();
@@ -2696,9 +2699,22 @@ public class StudyController(
         List<int> fallbackExampleIds;
         if (isNpgsql)
         {
-            studyExampleIds = studyDeckIdArray.Length > 0
-                ? await context.Database
-                    .SqlQueryRaw<int>(@"
+            if (studyDeckIdArray.Length > 0)
+            {
+                var sql = mediaTypeFilter != null
+                    ? @"
+                        SELECT esw.""ExampleSentenceId""
+                        FROM unnest({0}::int[], {1}::smallint[]) AS v(wid, ri)
+                        CROSS JOIN LATERAL (
+                            SELECT esw2.""ExampleSentenceId""
+                            FROM jiten.""ExampleSentenceWords"" esw2
+                            JOIN jiten.""ExampleSentences"" es ON es.""SentenceId"" = esw2.""ExampleSentenceId""
+                            JOIN jiten.""Decks"" d ON d.""DeckId"" = es.""DeckId"" AND d.""MediaType"" = ANY({3})
+                            WHERE esw2.""WordId"" = v.wid AND esw2.""ReadingIndex"" = v.ri
+                              AND es.""DeckId"" = ANY({2})
+                            LIMIT 1
+                        ) esw"
+                    : @"
                         SELECT esw.""ExampleSentenceId""
                         FROM unnest({0}::int[], {1}::smallint[]) AS v(wid, ri)
                         CROSS JOIN LATERAL (
@@ -2708,10 +2724,16 @@ public class StudyController(
                             WHERE esw2.""WordId"" = v.wid AND esw2.""ReadingIndex"" = v.ri
                               AND es.""DeckId"" = ANY({2})
                             LIMIT 1
-                        ) esw
-                    ", pairWordIds, pairReadingIndexes, studyDeckIdArray)
-                    .ToListAsync()
-                : [];
+                        ) esw";
+                var args = mediaTypeFilter != null
+                    ? new object[] { pairWordIds, pairReadingIndexes, studyDeckIdArray, mediaTypeFilter }
+                    : new object[] { pairWordIds, pairReadingIndexes, studyDeckIdArray };
+                studyExampleIds = await context.Database.SqlQueryRaw<int>(sql, args).ToListAsync();
+            }
+            else
+            {
+                studyExampleIds = [];
+            }
 
             if (studyExampleIds.Count >= request.Pairs.Count)
             {
@@ -2719,8 +2741,20 @@ public class StudyController(
             }
             else
             {
-                fallbackExampleIds = await context.Database
-                    .SqlQueryRaw<int>(@"
+                var fallbackSql = mediaTypeFilter != null
+                    ? @"
+                        SELECT esw.""ExampleSentenceId""
+                        FROM unnest({0}::int[], {1}::smallint[]) AS v(wid, ri)
+                        CROSS JOIN LATERAL (
+                            SELECT esw2.""ExampleSentenceId""
+                            FROM jiten.""ExampleSentenceWords"" esw2
+                            JOIN jiten.""ExampleSentences"" es ON es.""SentenceId"" = esw2.""ExampleSentenceId""
+                            JOIN jiten.""Decks"" d ON d.""DeckId"" = es.""DeckId"" AND d.""MediaType"" = ANY({2})
+                            WHERE esw2.""WordId"" = v.wid AND esw2.""ReadingIndex"" = v.ri
+                            ORDER BY esw2.""ExampleSentenceId""
+                            LIMIT 1
+                        ) esw"
+                    : @"
                         SELECT esw.""ExampleSentenceId""
                         FROM unnest({0}::int[], {1}::smallint[]) AS v(wid, ri)
                         CROSS JOIN LATERAL (
@@ -2729,18 +2763,25 @@ public class StudyController(
                             WHERE esw2.""WordId"" = v.wid AND esw2.""ReadingIndex"" = v.ri
                             ORDER BY esw2.""ExampleSentenceId""
                             LIMIT 1
-                        ) esw
-                    ", pairWordIds, pairReadingIndexes)
-                    .ToListAsync();
-
+                        ) esw";
+                var fallbackArgs = mediaTypeFilter != null
+                    ? new object[] { pairWordIds, pairReadingIndexes, mediaTypeFilter }
+                    : new object[] { pairWordIds, pairReadingIndexes };
+                fallbackExampleIds = await context.Database.SqlQueryRaw<int>(fallbackSql, fallbackArgs).ToListAsync();
             }
         }
         else
         {
             studyExampleIds = [];
-            fallbackExampleIds = await context.ExampleSentenceWords
+            var fallbackQuery = context.ExampleSentenceWords
                 .AsNoTracking()
-                .Where(esw => wordIds.Contains(esw.WordId))
+                .Where(esw => wordIds.Contains(esw.WordId));
+            if (mediaTypeFilter != null)
+            {
+                var mediaTypes = mediaTypeFilter.Select(m => (MediaType)m).ToList();
+                fallbackQuery = fallbackQuery.Where(esw => mediaTypes.Contains(esw.ExampleSentence!.Deck!.MediaType));
+            }
+            fallbackExampleIds = await fallbackQuery
                 .GroupBy(esw => new { esw.WordId, esw.ReadingIndex })
                 .Select(g => g.Min(esw => esw.ExampleSentenceId))
                 .ToListAsync();

--- a/Jiten.Api/Controllers/VocabularyController.cs
+++ b/Jiten.Api/Controllers/VocabularyController.cs
@@ -326,13 +326,13 @@ public class VocabularyController(JitenDbContext context, IDbContextFactory<Jite
     /// <param name="alreadyLoaded">A list of deck IDs already loaded on the client to avoid duplicates.</param>
     /// <param name="mediaType">Optional media type filter.</param>
     /// <returns>A list of example sentences with metadata.</returns>
-    [HttpPost("{wordId}/{readingIndex}/random-example-sentences/{mediaType?}")]
+    [HttpPost("{wordId}/{readingIndex}/random-example-sentences")]
     [SwaggerOperation(Summary = "Get random example sentences",
                       Description =
                           "Returns up to three random example sentences for the given word and reading index, excluding already loaded ones.")]
     [ProducesResponseType(typeof(List<ExampleSentenceDto>), StatusCodes.Status200OK)]
     public async Task<List<ExampleSentenceDto>> GetRandomExampleSentences([FromRoute] int wordId, [FromRoute] int readingIndex,
-                                                                          [FromBody] List<int> alreadyLoaded, [FromRoute] MediaType? mediaType = null)
+                                                                          [FromBody] List<int> alreadyLoaded, [FromQuery] List<MediaType>? mediaTypes = null)
     {
         // Subquery: distinct sentence IDs for this word+reading (not materialised)
         var sentenceIdSubquery = context.ExampleSentenceWords
@@ -347,7 +347,7 @@ public class VocabularyController(JitenDbContext context, IDbContextFactory<Jite
             .Join(context.Decks.AsNoTracking(),
                   s => s.DeckId, d => d.DeckId,
                   (s, d) => new { Sentence = s, Deck = d })
-            .Where(j => !mediaType.HasValue || j.Deck.MediaType == mediaType.Value)
+            .Where(j => mediaTypes == null || mediaTypes.Count == 0 || mediaTypes.Contains(j.Deck.MediaType))
             .Where(j => !alreadyLoaded.Contains(j.Deck.DeckId)
                      && (!j.Deck.ParentDeckId.HasValue || !alreadyLoaded.Contains(j.Deck.ParentDeckId.Value)))
             .OrderBy(_ => EF.Functions.Random())
@@ -362,7 +362,7 @@ public class VocabularyController(JitenDbContext context, IDbContextFactory<Jite
         return await BuildExampleSentenceDtos(picked, wordId, readingIndex);
     }
 
-    [HttpPost("{wordId}/{readingIndex}/example-sentences-by-difficulty/{mediaType?}")]
+    [HttpPost("{wordId}/{readingIndex}/example-sentences-by-difficulty")]
     [SwaggerOperation(Summary = "Get example sentences ordered by difficulty",
                       Description =
                           "Returns example sentences for the given word and reading index, ordered by difficulty score. " +
@@ -370,7 +370,7 @@ public class VocabularyController(JitenDbContext context, IDbContextFactory<Jite
     [ProducesResponseType(typeof(ExampleSentencesByDifficultyResponse), StatusCodes.Status200OK)]
     public async Task<ExampleSentencesByDifficultyResponse> GetExampleSentencesByDifficulty(
         [FromRoute] int wordId, [FromRoute] int readingIndex,
-        [FromBody] List<int> alreadyLoaded, [FromRoute] MediaType? mediaType = null,
+        [FromBody] List<int> alreadyLoaded, [FromQuery] List<MediaType>? mediaTypes = null,
         [FromQuery] float minDifficulty = 0f, [FromQuery] float maxDifficulty = 0.5f,
         [FromQuery] bool descending = false, [FromQuery] int take = 3)
     {
@@ -413,7 +413,7 @@ public class VocabularyController(JitenDbContext context, IDbContextFactory<Jite
                 .Join(context.Decks.AsNoTracking(),
                       s => s.DeckId, d => d.DeckId,
                       (s, d) => new { Sentence = s, Deck = d })
-                .Where(j => !mediaType.HasValue || j.Deck.MediaType == mediaType.Value)
+                .Where(j => mediaTypes == null || mediaTypes.Count == 0 || mediaTypes.Contains(j.Deck.MediaType))
                 .Where(j => !excludeIds.Contains(j.Deck.DeckId)
                          && (!j.Deck.ParentDeckId.HasValue || !excludeIds.Contains(j.Deck.ParentDeckId.Value)))
                 .OrderBy(_ => EF.Functions.Random())

--- a/Jiten.Api/Dtos/StudySettingsDto.cs
+++ b/Jiten.Api/Dtos/StudySettingsDto.cs
@@ -127,4 +127,7 @@ public class StudySettingsDto
 
     [JsonPropertyName("timezone")]
     public string? Timezone { get; set; }
+
+    [JsonPropertyName("exampleSentenceMediaTypes")]
+    public List<int>? ExampleSentenceMediaTypes { get; set; }
 }

--- a/Jiten.Tests/Integration/StudyTests.cs
+++ b/Jiten.Tests/Integration/StudyTests.cs
@@ -240,8 +240,8 @@ public class StudyTests(JitenWebApplicationFactory factory)
                 maxReviewsPerDay = 100,
                 gradingButtons = 2,
                 interleaving = "newFirst",
-
-                reviewFrom = "allTracked"
+                reviewFrom = "allTracked",
+                exampleSentenceMediaTypes = new[] { 4, 5, 6, 7, 8 }
             });
         var updateResponse = await _client.SendAsync(update);
         updateResponse.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -253,6 +253,8 @@ public class StudyTests(JitenWebApplicationFactory factory)
         var body2 = await get2Response.Content.ReadFromJsonAsync<JsonElement>();
         body2.GetProperty("newCardsPerDay").GetInt32().Should().Be(10);
         body2.GetProperty("gradingButtons").GetInt32().Should().Be(2);
+        body2.GetProperty("exampleSentenceMediaTypes").EnumerateArray()
+            .Select(e => e.GetInt32()).Should().BeEquivalentTo([4, 5, 6, 7, 8]);
     }
 
     [Fact]

--- a/Jiten.Web/app/components/SettingsSrsStudy.vue
+++ b/Jiten.Web/app/components/SettingsSrsStudy.vue
@@ -14,6 +14,7 @@
   onMounted(async () => {
     await srsStore.fetchSettings();
     Object.assign(form, srsStore.studySettings);
+    exampleSentenceSource.value = form.exampleSentenceMediaTypes == null ? [null] : [...form.exampleSentenceMediaTypes];
     if (!form.timezone) applyDetectedTimezone();
     loaded.value = true;
     tickInterval = setInterval(() => { nowMinute.value = Date.now(); }, 60_000);
@@ -52,6 +53,33 @@
     { label: 'Easiest', value: 'EasiestFirst' },
     { label: 'Hardest', value: 'HardestFirst' },
   ];
+
+  const exampleSentenceSourceOptions = [
+    { label: 'All', value: null as number | null },
+    { label: 'VN', value: 7 },
+    { label: 'Novel', value: 4 },
+    { label: 'WN', value: 8 },
+    { label: 'VG', value: 6 },
+    { label: 'NF', value: 5 },
+  ];
+
+  // null in the array represents "All"
+  const exampleSentenceSource = ref<(number | null)[]>(
+    form.exampleSentenceMediaTypes == null ? [null] : [...form.exampleSentenceMediaTypes]
+  );
+
+  function onExampleSourceChange(val: (number | null)[]) {
+    const hadAll = form.exampleSentenceMediaTypes === null;
+    const nowHasAll = val.includes(null);
+    if (!hadAll && nowHasAll) {
+      form.exampleSentenceMediaTypes = null;
+      exampleSentenceSource.value = [null];
+    } else {
+      const specific = val.filter((v): v is number => v !== null);
+      form.exampleSentenceMediaTypes = specific.length > 0 ? specific : null;
+      exampleSentenceSource.value = specific.length > 0 ? specific : [null];
+    }
+  }
 
   function getUtcOffsetMinutes(zone: string, date?: Date): number {
     const parts = new Intl.DateTimeFormat('en-US', { timeZone: zone, hour: 'numeric', hour12: false, timeZoneName: 'shortOffset' })
@@ -297,6 +325,15 @@
                 </Tooltip>
               </label>
               <SelectButton v-model="form.exampleSentenceSorting" :options="exampleSentenceSortingOptions" option-label="label" option-value="value" :allow-empty="false" />
+            </div>
+            <div v-if="form.exampleSentencePosition !== 'Hidden'" class="mt-2">
+              <label class="text-sm mb-1 block">
+                Example Sentence Media
+                <Tooltip content="Only show example sentences of these types.<br>**VN** — Visual Novel<br>**WN** — Web Novel<br>**VG** — Video Games<br>**NF** — Non-Fiction" placement="right">
+                  <i class="pi pi-info-circle text-xs text-surface-400 ml-1 cursor-help" />
+                </Tooltip>
+              </label>
+              <SelectButton :model-value="exampleSentenceSource" :options="exampleSentenceSourceOptions" option-label="label" option-value="value" :allow-empty="false" :multiple="true" class="flex-wrap" @update:model-value="onExampleSourceChange" />
             </div>
           </div>
           <div class="flex items-center gap-2">

--- a/Jiten.Web/app/components/SrsStudyCard.vue
+++ b/Jiten.Web/app/components/SrsStudyCard.vue
@@ -125,11 +125,11 @@
     try {
       const alreadyLoaded = extraSentences.value.map(s => s.sourceDeck.deckId);
 
+      const mediaTypesParam = srsStore.studySettings.exampleSentenceMediaTypes?.map(t => `mediaTypes=${t}`).join('&') ?? '';
+
       if (sorting === 'Random') {
-        const results = await $api<ExampleSentence[]>(
-          `vocabulary/${props.card.wordId}/${props.card.readingIndex}/random-example-sentences`,
-          { method: 'POST', body: alreadyLoaded },
-        );
+        const url = `vocabulary/${props.card.wordId}/${props.card.readingIndex}/random-example-sentences${mediaTypesParam ? '?' + mediaTypesParam : ''}`;
+        const results = await $api<ExampleSentence[]>(url, { method: 'POST', body: alreadyLoaded });
 
         if (results.length === 0) {
           canLoadMoreSentences.value = false;
@@ -139,8 +139,12 @@
         extraSentences.value.push(...results);
       } else {
         const descending = sorting === 'HardestFirst';
+        const params = new URLSearchParams({ minDifficulty: String(nextBandMin.value), maxDifficulty: String(nextBandMax.value), descending: String(descending) });
+        if (srsStore.studySettings.exampleSentenceMediaTypes) {
+          for (const t of srsStore.studySettings.exampleSentenceMediaTypes) params.append('mediaTypes', String(t));
+        }
         const results = await $api<ExampleSentencesByDifficultyResponse>(
-          `vocabulary/${props.card.wordId}/${props.card.readingIndex}/example-sentences-by-difficulty?minDifficulty=${nextBandMin.value}&maxDifficulty=${nextBandMax.value}&descending=${descending}`,
+          `vocabulary/${props.card.wordId}/${props.card.readingIndex}/example-sentences-by-difficulty?${params}`,
           { method: 'POST', body: alreadyLoaded },
         );
 

--- a/Jiten.Web/app/components/VocabularyDetail.vue
+++ b/Jiten.Web/app/components/VocabularyDetail.vue
@@ -178,7 +178,7 @@
     let url = `vocabulary/${props.wordId}/${currentReadingIndex.value}/random-example-sentences`;
 
     if (selectedMediaType.value != null) {
-      url += '/' + selectedMediaType.value;
+      url += '?mediaTypes=' + selectedMediaType.value;
     }
 
     const alreadyLoaded = exampleSentences.value.map((sentence) => sentence.sourceDeck.deckId);
@@ -200,15 +200,14 @@
   async function getExampleSentencesByDifficulty() {
     isLoadingExampleSentences.value = true;
     const descending = selectedSortMode.value === 'hardest';
-    let url = `vocabulary/${props.wordId}/${currentReadingIndex.value}/example-sentences-by-difficulty`;
-
+    const params = new URLSearchParams({ minDifficulty: String(nextBandMin.value), maxDifficulty: String(nextBandMax.value), descending: String(descending) });
     if (selectedMediaType.value != null) {
-      url += '/' + selectedMediaType.value;
+      params.append('mediaTypes', String(selectedMediaType.value));
     }
 
     const alreadyLoaded = exampleSentences.value.map((sentence) => sentence.sourceDeck.deckId);
     const results = await $api<ExampleSentencesByDifficultyResponse>(
-      `${url}?minDifficulty=${nextBandMin.value}&maxDifficulty=${nextBandMax.value}&descending=${descending}`,
+      `vocabulary/${props.wordId}/${currentReadingIndex.value}/example-sentences-by-difficulty?${params}`,
       { method: 'POST', body: alreadyLoaded },
     );
 

--- a/Jiten.Web/app/stores/srsStore.ts
+++ b/Jiten.Web/app/stores/srsStore.ts
@@ -81,6 +81,7 @@ export const useSrsStore = defineStore('srs', () => {
     showReviewActivity: true,
     showReviewForecast: true,
     timezone: 'Europe/London',
+    exampleSentenceMediaTypes: null,
   });
   const sessionStats = ref({
     cardsReviewed: 0,

--- a/Jiten.Web/app/types/types.ts
+++ b/Jiten.Web/app/types/types.ts
@@ -882,6 +882,7 @@ export interface StudySettingsDto {
   showReviewActivity: boolean;
   showReviewForecast: boolean;
   timezone: string | null;
+  exampleSentenceMediaTypes: number[] | null;
 }
 
 export interface CardExamplesResponse {


### PR DESCRIPTION
In the settings page in SRS-preview, I added an option for you to choose what types of media the sentences can come from (including the extra sentences). I used abbreviations to avoid wrapping, but if you wanted to change it you can change each item to it's full word (eg. Visual Novel instead of VN) and let it wrap. I didn't want to mess with the UI too much so I simplified things.