### PR TITLE
Minor parser fixes

### DIFF
--- a/Jiten.Parser/Parser.cs
+++ b/Jiten.Parser/Parser.cs
@@ -2521,15 +2521,20 @@ namespace Jiten.Parser
             }
         }
 
-        // X+に/X+でも pairs lexicalized as adverbs in JMDict whose X is not a strong standalone
-        // word. Hyper-common standalone nouns stay split even when a combined entry exists
-        // (本当に, 絶対に, 外に, ように) — that's the project segmentation convention — so these
-        // are curated rather than derived from entry existence.
-        private static readonly HashSet<string> LexicalizedAdverbPairs = ["フルに", "無性に", "意地でも"];
+        // Particles allowed to open an expression window in TryMatchCompoundWindow. Curated
+        // because particles in general would over-merge (とは, には have genuine compositional
+        // uses); しか has no reading other than the expression head of しかない/しかねぇ.
+        private static readonly HashSet<string> ParticleExpressionOpeners = ["しか"];
+
+        // X+に/X+でも pairs lexicalized as adverbs in JMDict. Curated rather than derived from
+        // entry existence because many X+に pairs have genuine case-particle readings that an
+        // automatic merge would destroy (それに気づいた, ことに決めた, 外に出る). Pairs whose
+        // combined surface is effectively always the adverb (絶対に) are safe to list.
+        private static readonly HashSet<string> LexicalizedAdverbPairs = ["フルに", "無性に", "意地でも", "絶対に"];
 
         /// Merges X+に into a single token when the combined surface is a lexicalized adverb:
         /// any X的+に (always adverbial, JMDict entry required) or a curated pair (フルに, 無性に,
-        /// 意地でも). Bare entry existence is deliberately NOT enough — それに/ことに/本当に would
+        /// 意地でも, 絶対に). Bare entry existence is deliberately NOT enough — それに/ことに would
         /// merge over genuine case-particle uses.
         private static void CombineLexicalAdverbs(List<SentenceInfo> sentences)
         {
@@ -4312,6 +4317,23 @@ namespace Jiten.Parser
                 if (result.HasValue) return result;
             }
 
+            // Colloquial negative ねぇ/ねえ/ねー (= ない) blocks expression windows because the
+            // candidate is built from the literal dictForm (ろくでも+ねぇ never hits a lookup key).
+            // Sudachi normalizes these tokens to 無い, so retry with the canonical ない ending —
+            // the deconjugator maps the surface back (ろくでもねぇ → ろくでもない) for the
+            // conjugation chain on the merged token. Covers 仕方ねぇ, とんでもねぇ, しかねぇ etc.
+            if ((verb.PartOfSpeech == PartOfSpeech.IAdjective || verb.NormalizedForm is "無い" or "ない")
+                && dictForm.Length >= 2
+                && (dictForm.EndsWith("ねぇ", StringComparison.Ordinal)
+                    || dictForm.EndsWith("ねえ", StringComparison.Ordinal)
+                    || dictForm.EndsWith("ねー", StringComparison.Ordinal)))
+            {
+                var naiForm = dictForm[..^2] + "ない";
+                result = TryMatchCompoundWindow(wordInfos, wordIndex, lastConsumedIndex, naiForm, forceExpressionOnly,
+                    HiraRollingHash(naiForm), prefCumHash, prefCumLen);
+                if (result.HasValue) return result;
+            }
+
             if (dictForm != verb.Text && verb.Text.Length > dictForm.Length)
             {
                 var deconj = Deconjugator.Instance.Deconjugate(verb.Text);
@@ -4459,7 +4481,13 @@ namespace Jiten.Parser
                     continue;
 
                 var firstWord = wordInfos[startIndex];
-                if (firstWord.PartOfSpeech is PartOfSpeech.Particle or PartOfSpeech.Interjection)
+                // Particles never open expression windows (とは/には would over-merge), except a
+                // curated few that only exist as expression heads: Vしか+ない is unmatchable
+                // otherwise. Curated openers are forced expression-only below.
+                bool curatedParticleOpener = firstWord.PartOfSpeech == PartOfSpeech.Particle
+                                             && ParticleExpressionOpeners.Contains(firstWord.Text);
+                if (firstWord.PartOfSpeech is PartOfSpeech.Particle or PartOfSpeech.Interjection
+                    && !curatedParticleOpener)
                     continue;
                 if (firstWord is { PartOfSpeech: PartOfSpeech.Conjunction, Text.Length: 1 })
                     continue;
@@ -4497,7 +4525,8 @@ namespace Jiten.Parser
                 if (!_compoundHashSet!.Contains(candidateHash))
                     continue;
 
-                bool expressionOnly = forceExpressionOnly || firstWord.PartOfSpeech is PartOfSpeech.Suffix or PartOfSpeech.Auxiliary or PartOfSpeech.Adverb;
+                bool expressionOnly = forceExpressionOnly || curatedParticleOpener
+                    || firstWord.PartOfSpeech is PartOfSpeech.Suffix or PartOfSpeech.Auxiliary or PartOfSpeech.Adverb;
 
                 // Build candidate span on stack: [prefix tokens...][dictForm]
                 var candidateSpan = candidateBuf[..totalLen];

--- a/Jiten.Parser/Parser.cs
+++ b/Jiten.Parser/Parser.cs
@@ -58,6 +58,11 @@ namespace Jiten.Parser
         private static readonly Regex MultiLongVowelRegex = new(@"ー{2,}", RegexOptions.Compiled);
         private static readonly Regex DialogueRegex = new(@"[「『].{0,200}?[」』]", RegexOptions.Compiled | RegexOptions.Singleline);
 
+        // Opening quote/bracket characters that begin a fresh utterance span (used to mark the
+        // following content token as sentence-initial).
+        private static readonly HashSet<char> OpeningQuoteChars =
+            ['「', '『', '（', '〈', '《', '【', '〔', '｢', '(', '“', '‘', '"', '\''];
+
         // Surface-text misparse tokens to remove after repair stages (deferred from MorphologicalAnalyser
         // so RepairLongVowelMisparses can use them for backward-merge reconstruction)
         private static readonly HashSet<string> MisparsesRemove =
@@ -175,6 +180,9 @@ namespace Jiten.Parser
 
             CombineNounCompounds(sentences);
             DbgDump("CombineNounCompounds");
+
+            ReclassifyLeftoverPrefixChars(sentences);
+            DbgDump("ReclassifyLeftoverPrefixChars");
 
             if (sw != null) { timings!.PrepNounCompoundsMs += sw.Elapsed.TotalMilliseconds; sw.Restart(); }
 
@@ -2535,7 +2543,8 @@ namespace Jiten.Parser
         /// Merges X+に into a single token when the combined surface is a lexicalized adverb:
         /// any X的+に (always adverbial, JMDict entry required) or a curated pair (フルに, 無性に,
         /// 意地でも, 絶対に). Bare entry existence is deliberately NOT enough — それに/ことに would
-        /// merge over genuine case-particle uses.
+        /// merge over genuine case-particle uses. Also merges Noun+ほど when the pair is a
+        /// lexicalized adverb (山ほど); 三日ほど/5分ほど ("approximately") have no entry and stay split.
         private static void CombineLexicalAdverbs(List<SentenceInfo> sentences)
         {
             foreach (var sentence in sentences)
@@ -2561,8 +2570,10 @@ namespace Jiten.Parser
                                         && word.Text.EndsWith('的');
                         bool isCuratedPair = next.word.Text is "に" or "でも"
                                              && LexicalizedAdverbPairs.Contains(word.Text + next.word.Text);
+                        bool isHodoPair = next.word.Text == "ほど"
+                                          && next.word.PartOfSpeech == PartOfSpeech.Particle;
 
-                        if ((isNiPair || isCuratedPair) && HasLexicalAdverbEntry(word.Text + next.word.Text))
+                        if ((isNiPair || isCuratedPair || isHodoPair) && HasLexicalAdverbEntry(word.Text + next.word.Text))
                         {
                             var combinedText = word.Text + next.word.Text;
                             var merged = new WordInfo(word)
@@ -3150,6 +3161,53 @@ namespace Jiten.Parser
 
                 if (anySplit)
                     sentence.Words = result;
+            }
+        }
+
+        // Kanji that are bound prefixes (接頭辞): when prepended to a noun they take their
+        // prefix reading, and they are NOT common standalone nouns. Curated rather than derived
+        // from a Prefix lookup entry, because free-noun kanji (前/大/本/後…) also carry an n-pref
+        // entry yet read as the noun (前準備 → 前 まえ, not 前 ぜん). 総→そう (not ふさ) etc.
+        private static readonly HashSet<char> BoundPrefixKanji =
+            ['総', '諸', '各', '準', '副', '反', '超', '非', '未', '汎', '准', '旧'];
+
+        /// After noun-compound recombination, a single-kanji token left over from
+        /// SplitUnknownNounTokens that is a bound prefix before a following noun should resolve to
+        /// its prefix reading, not a noun/counter homograph: 総本部 splits to 総 + 本部 (recombined),
+        /// and 総 must resolve to 総(そう, pref) not 総(ふさ, tuft/cluster). Gated on BoundPrefixKanji
+        /// so free-noun kanji (前/大/本) keep their noun reading.
+        private static void ReclassifyLeftoverPrefixChars(List<SentenceInfo> sentences)
+        {
+            foreach (var sentence in sentences)
+            {
+                var words = sentence.Words;
+                for (int i = 0; i < words.Count - 1; i++)
+                {
+                    var word = words[i].word;
+                    if (word.PartOfSpeech is not (PartOfSpeech.Noun or PartOfSpeech.CommonNoun)
+                        || word.Text.Length != 1
+                        || !BoundPrefixKanji.Contains(word.Text[0]))
+                        continue;
+
+                    var next = words[i + 1].word;
+                    if (next.PartOfSpeech is not (PartOfSpeech.Noun or PartOfSpeech.CommonNoun
+                        or PartOfSpeech.NaAdjective or PartOfSpeech.NominalAdjective))
+                        continue;
+
+                    if (!_lookups.TryGetValue(word.Text, out var ids))
+                        continue;
+
+                    int? prefixId = null;
+                    foreach (var id in ids)
+                        if (WordMeta.TryGetValue(id, out var meta) && meta.GetPrimaryPos() == PartOfSpeech.Prefix)
+                        { prefixId = id; break; }
+
+                    if (prefixId == null)
+                        continue;
+
+                    word.PartOfSpeech = PartOfSpeech.Prefix;
+                    word.PreMatchedWordId = prefixId;
+                }
             }
         }
 
@@ -4148,13 +4206,29 @@ namespace Jiten.Parser
             foreach (var sentence in sentences)
             {
                 bool first = true;
+                // An opening quote/bracket starts a fresh utterance span: the next content token
+                // is utterance-initial even when a speaker tag precedes it (【テオドール】「ああ…
+                // → ああ counts as sentence-initial). Blank space between the quote and the word
+                // is transparent and must not consume the flag.
+                bool afterOpeningQuote = false;
                 foreach (var (word, _, _) in sentence.Words)
                 {
                     if (word.PartOfSpeech == PartOfSpeech.SupplementarySymbol)
+                    {
+                        if (word.Text.Length > 0 && OpeningQuoteChars.Contains(word.Text[^1]))
+                            afterOpeningQuote = true;
                         continue;
+                    }
+                    if (word.PartOfSpeech == PartOfSpeech.BlankSpace)
+                    {
+                        flatTokens.Add(word);
+                        sentenceInitial.Add(first || afterOpeningQuote);
+                        continue;
+                    }
                     flatTokens.Add(word);
-                    sentenceInitial.Add(first);
+                    sentenceInitial.Add(first || afterOpeningQuote);
                     first = false;
+                    afterOpeningQuote = false;
                 }
             }
 

--- a/Jiten.Parser/Stages/MorphologicalAnalyser.CombineStages.cs
+++ b/Jiten.Parser/Stages/MorphologicalAnalyser.CombineStages.cs
@@ -351,6 +351,16 @@ public partial class MorphologicalAnalyser
             wordInfos[i + 2].DictionaryForm is "思う" or "言う" or "聞く" or "考える" or "感じる")
             return true;
 
+        // Re-cut って before a noun (なくなった+って+話), punctuation, or sentence end is the
+        // quotative/たって particle — a te-form continuation needs a verb/auxiliary after it.
+        // Re-merging makes an unresolvable blob (なくなったって has no deconjugation path) that
+        // would be dropped from output entirely.
+        if (nextWord is { Text: "って", DictionaryForm: "って" } &&
+            (i + 2 >= wordInfos.Count ||
+             wordInfos[i + 2].PartOfSpeech is PartOfSpeech.Noun or PartOfSpeech.CommonNoun
+                 or PartOfSpeech.SupplementarySymbol))
+            return true;
+
         // Benefactive auxiliaries after a te-form stay separate tokens (堪能させて|いただきます,
         // 繕って|貰いて). The て+貰う/いただく deconjugator rules exist for chain display on tokens
         // merged by the Dependant path (して貰いたい) — they must not widen this stage's merges.
@@ -814,7 +824,9 @@ public partial class MorphologicalAnalyser
             if ((wordInfos[i].PartOfSpeech == PartOfSpeech.Suffix || wordInfos[i].HasPartOfSpeechSection(PartOfSpeechSection.Suffix))
                 && (wordInfos[i].DictionaryForm == "っこ"
                     || wordInfos[i].DictionaryForm == "さ"
-                    || wordInfos[i].DictionaryForm == "がる"
+                    // がる only attaches to adjective stems (怖がる) — never to a pronoun host
+                    // (何|がって is case-particle が + quotative って, not 何がる)
+                    || (wordInfos[i].DictionaryForm == "がる" && currentWord.PartOfSpeech != PartOfSpeech.Pronoun)
                     || (wordInfos[i].DictionaryForm is "ぶり" or "振り" &&
                         currentWord.PartOfSpeech == PartOfSpeech.IAdjective &&
                         !currentWord.Text.EndsWith("い") && currentWord.DictionaryForm.EndsWith("い"))

--- a/Jiten.Parser/Stages/MorphologicalAnalyser.RepairStages.cs
+++ b/Jiten.Parser/Stages/MorphologicalAnalyser.RepairStages.cs
@@ -645,6 +645,36 @@ public partial class MorphologicalAnalyser
                 }
             }
 
+            // Pattern 5: small-vowel elongation fused onto a conjugation ending. Sudachi emits
+            // [kana][run of ≥2 identical small vowels] as one OOV noun: 来やがれぇぇぇ →
+            // 来 + やが + れぇぇぇ. Strip the elongation and reattach the leading kana to the
+            // preceding verb/auxiliary when it makes a real conjugation (やが+れ → やがれ = やがる
+            // imperative). A bare noun-tagged stem (移れぇぇぇ → 移 noun) fails the verb/aux gate
+            // and is left as-is.
+            if (prev.PartOfSpeech is PartOfSpeech.Verb or PartOfSpeech.Auxiliary &&
+                current.PartOfSpeech is PartOfSpeech.Noun or PartOfSpeech.CommonNoun or PartOfSpeech.Interjection &&
+                IsTrailingSmallVowelRun(current.Text, out int coreLen))
+            {
+                var core = current.Text[..coreLen];
+                var candidate = NormalizeToHiragana(prev.Text + core);
+                var prevDictHiragana = NormalizeToHiragana(prev.DictionaryForm);
+                bool valid = candidate != prevDictHiragana && deconjugator.Deconjugate(candidate).Any(f =>
+                    f.Text == prevDictHiragana &&
+                    f.Tags.Any(t => t.StartsWith("v", StringComparison.Ordinal)));
+
+                if (valid)
+                {
+                    result[^1] = new WordInfo(prev)
+                    {
+                        Text = prev.Text + core,
+                        Reading = prev.Reading + WanaKanaShaapu.WanaKana.ToKatakana(core),
+                        EndOffset = current.StartOffset >= 0 ? current.StartOffset + coreLen : prev.EndOffset
+                    };
+                    changed = true;
+                    continue;
+                }
+            }
+
             result.Add(current);
         }
 
@@ -904,6 +934,40 @@ public partial class MorphologicalAnalyser
         for (int i = 0; i < wordInfos.Count;)
         {
             WordInfo w1 = wordInfos[i];
+
+            // Katakana mora stolen from a name by a following hiragana-dict prenominal: Sudachi
+            // cuts カティア|の as カティ|アの (アの = homograph of 連体詞 あの). A 連体詞 whose dict
+            // form is hiragana but whose surface starts with katakana means the leading mora
+            // belongs to the preceding katakana name — return it and emit the remainder (の) as a
+            // particle. (カティ+ア = カティア, kept as an OOV name token.)
+            if (w1.PartOfSpeech == PartOfSpeech.PrenounAdjectival
+                && w1.Text.Length >= 2
+                && IsKatakanaTextChar(w1.Text[0]) && w1.Text[0] != 'ー'
+                && w1.Text[1..].All(c => c is >= '぀' and <= 'ゟ')
+                && KanaConverter.ToHiragana(w1.Text) == w1.DictionaryForm
+                && newList.Count > 0
+                && newList[^1].PartOfSpeech is PartOfSpeech.Noun or PartOfSpeech.Name
+                && IsAllKatakanaText(newList[^1].Text))
+            {
+                var prev = newList[^1];
+                var stolen = w1.Text[0].ToString();
+                var remainder = w1.Text[1..];
+                prev.Text += stolen;
+                prev.DictionaryForm = prev.Text;
+                prev.NormalizedForm = prev.Text;
+                prev.Reading += stolen;
+                if (prev.EndOffset >= 0) prev.EndOffset += 1;
+                newList.Add(new WordInfo
+                {
+                    Text = remainder, DictionaryForm = remainder, NormalizedForm = remainder,
+                    PartOfSpeech = PartOfSpeech.Particle,
+                    Reading = WanaKanaShaapu.WanaKana.ToKatakana(remainder),
+                    StartOffset = prev.EndOffset,
+                    EndOffset = w1.EndOffset
+                });
+                i++;
+                continue;
+            }
 
             // Sudachi misclassifies katakana particle sequences as nouns (e.g. ノヨ → name 乃代).
             // Split into individual particles: ノ + ヨ, ノネ, ノサ, etc.
@@ -2276,6 +2340,25 @@ public partial class MorphologicalAnalyser
         return result;
     }
 
+    // A trailing run of ≥2 identical small vowels (ぇぇぇ, ぁぁ) is expressive elongation, not part
+    // of a word. Returns the length of the leading core (≥1) when such a run is present.
+    private static bool IsTrailingSmallVowelRun(string text, out int coreLen)
+    {
+        coreLen = text.Length;
+        const string smallVowels = "ぁぃぅぇぉ";
+        int i = text.Length - 1;
+        char runChar = '\0';
+        int runCount = 0;
+        while (i >= 0 && smallVowels.IndexOf(text[i]) >= 0 && (runCount == 0 || text[i] == runChar))
+        {
+            runChar = text[i];
+            runCount++;
+            i--;
+        }
+        coreLen = i + 1;
+        return runCount >= 2 && coreLen >= 1;
+    }
+
     private static readonly HashSet<string> CaseParticles =
         ["に", "を", "が", "へ", "で", "と", "は", "も", "か", "から", "より", "まで", "の"];
 
@@ -2778,6 +2861,15 @@ public partial class MorphologicalAnalyser
                     }
                 }
                 if (allSameInterjection) continue;
+
+                // An interjection followed by the standalone adverb そう (えっ+そう, あっ+そう =
+                // "huh — I see") is two utterance units. そう never fuses into a preceding
+                // interjection: neither the kana-noun key (えっそう) nor the colloquial verb
+                // deconjugation (えっそう→得る) is valid. ふん+ばったり (→踏ん張る -tari) is
+                // unaffected — its second token is ばったり, not そう.
+                if (wordInfos[i].PartOfSpeech == PartOfSpeech.Interjection
+                    && wordInfos[i + 1].Text == "そう")
+                    continue;
 
                 string combinedText = spanLen switch
                 {

--- a/Jiten.Parser/Stages/MorphologicalAnalyser.RepairStages.cs
+++ b/Jiten.Parser/Stages/MorphologicalAnalyser.RepairStages.cs
@@ -952,17 +952,22 @@ public partial class MorphologicalAnalyser
                 var prev = newList[^1];
                 var stolen = w1.Text[0].ToString();
                 var remainder = w1.Text[1..];
-                prev.Text += stolen;
-                prev.DictionaryForm = prev.Text;
-                prev.NormalizedForm = prev.Text;
-                prev.Reading += stolen;
-                if (prev.EndOffset >= 0) prev.EndOffset += 1;
+                var mergedText = prev.Text + stolen;
+                int mergedEndOffset = prev.EndOffset >= 0 ? prev.EndOffset + 1 : prev.EndOffset;
+                newList[^1] = new WordInfo(prev)
+                {
+                    Text = mergedText,
+                    DictionaryForm = mergedText,
+                    NormalizedForm = mergedText,
+                    Reading = prev.Reading + stolen,
+                    EndOffset = mergedEndOffset
+                };
                 newList.Add(new WordInfo
                 {
                     Text = remainder, DictionaryForm = remainder, NormalizedForm = remainder,
                     PartOfSpeech = PartOfSpeech.Particle,
                     Reading = WanaKanaShaapu.WanaKana.ToKatakana(remainder),
-                    StartOffset = prev.EndOffset,
+                    StartOffset = mergedEndOffset,
                     EndOffset = w1.EndOffset
                 });
                 i++;
@@ -998,6 +1003,7 @@ public partial class MorphologicalAnalyser
                     NormalizedForm = "いいか",
                     PartOfSpeech = PartOfSpeech.Expression,
                     Reading = "イイカ",
+                    PreMatchedWordId = 2555520,
                     StartOffset = w1.StartOffset,
                     EndOffset = ka.EndOffset
                 });

--- a/Jiten.Parser/Stages/MorphologicalAnalyser.RepairStages.cs
+++ b/Jiten.Parser/Stages/MorphologicalAnalyser.RepairStages.cs
@@ -915,6 +915,32 @@ public partial class MorphologicalAnalyser
                 continue;
             }
 
+            // Clause-initial いいか、/いいか! is the "Listen!" interjection (JMDict 2555520), not
+            // adjective いい + question か. Gated on clause position AND a following 、/! so the
+            // genuine question reading keeps its split everywhere else (行っていいか分からない,
+            // standalone いいか?).
+            if (w1 is { Text: "いい", PartOfSpeech: PartOfSpeech.IAdjective }
+                && (newList.Count == 0 || newList[^1].PartOfSpeech is PartOfSpeech.SupplementarySymbol
+                    or PartOfSpeech.Symbol or PartOfSpeech.BlankSpace)
+                && i + 2 < wordInfos.Count
+                && wordInfos[i + 1] is { Text: "か", PartOfSpeech: PartOfSpeech.Particle }
+                && wordInfos[i + 2].Text is "、" or "!" or "！")
+            {
+                var ka = wordInfos[i + 1];
+                newList.Add(new WordInfo
+                {
+                    Text = "いいか",
+                    DictionaryForm = "いいか",
+                    NormalizedForm = "いいか",
+                    PartOfSpeech = PartOfSpeech.Expression,
+                    Reading = "イイカ",
+                    StartOffset = w1.StartOffset,
+                    EndOffset = ka.EndOffset
+                });
+                i += 2;
+                continue;
+            }
+
             // A case-particle が cannot follow conjunctive から — the kana verb がなる "to yell"
             // (2101910, uk) is the only grammatical reading (頼むからがなるな). No dictionary
             // entry: a がなる row would steal ベルが鳴る-type splits lattice-wide.
@@ -2260,6 +2286,10 @@ public partial class MorphologicalAnalyser
     // that actually produces a JMDict word (悪|いっ|て → 悪い ✓, ギシギシ|いっ|て → ギシギシい ✗).
     private static readonly HashSet<string> IuIkuDictForms = ["いう", "言う", "いく", "行く"];
 
+    // Demonstratives whose exclamation homograph (それっ!) Sudachi prefers before って;
+    // the stripped form is re-tagged Pronoun so lookup picks the everyday word.
+    private static readonly HashSet<string> QuotativeStrippedPronouns = ["それ", "これ", "あれ", "どれ"];
+
     // Clause-final shapes that can precede sentence-final かな. Nouns and case particles
     // (に/と) are deliberately excluded so どうにかなって/なんとかなって/夢かなって keep
     // their te-form-of-なる/かなう reading.
@@ -2355,6 +2385,61 @@ public partial class MorphologicalAnalyser
                     StartOffset = fusedThief.StartOffset >= 0 ? fusedThief.StartOffset + 1 : -1,
                     EndOffset = fusedThief.EndOffset
                 });
+                changed = true;
+                continue;
+            }
+
+            // Interjection homograph stealing the っ of a quotative って: それっ|て → それ + って.
+            // Sudachi's own NormalizedForm vouches for the stripped form (それっ → それ), so the
+            // re-cut is safe; without it CombineTte glues the pair back into a bogus "te form"
+            // of the exclamation entry. Demonstrative strips are re-tagged Pronoun so the lookup
+            // matches それ/これ the word, not それ! the shout.
+            if (i + 1 < wordInfos.Count
+                && wordInfos[i].PartOfSpeech == PartOfSpeech.Interjection
+                && wordInfos[i].Text.Length >= 2
+                && wordInfos[i].Text[^1] == 'っ'
+                && wordInfos[i + 1].Text == "て"
+                && wordInfos[i].NormalizedForm == wordInfos[i].Text[..^1])
+            {
+                var interjThief = wordInfos[i];
+                var interjStripped = interjThief.Text[..^1];
+                result.Add(new WordInfo(interjThief)
+                {
+                    Text = interjStripped,
+                    DictionaryForm = interjStripped,
+                    NormalizedForm = interjStripped,
+                    PartOfSpeech = QuotativeStrippedPronouns.Contains(interjStripped)
+                        ? PartOfSpeech.Pronoun
+                        : interjThief.PartOfSpeech,
+                    EndOffset = interjThief.EndOffset >= 0 ? interjThief.EndOffset - 1 : -1
+                });
+                AddTte(interjThief, wordInfos[i + 1]);
+                i++;
+                changed = true;
+                continue;
+            }
+
+            // がる suffix misread before a quotative って: 何|がっ|て → 何 + が + って.
+            // がる attaches to adjective stems (怖がる), never to a pronoun, so after a pronoun
+            // the only grammatical cut is case-particle が + quotative って.
+            if (i + 1 < wordInfos.Count
+                && wordInfos[i] is { Text: "がっ", PartOfSpeech: PartOfSpeech.Suffix, DictionaryForm: "がる" }
+                && wordInfos[i + 1].Text == "て"
+                && result.Count > 0 && result[^1].PartOfSpeech == PartOfSpeech.Pronoun)
+            {
+                var gaThief = wordInfos[i];
+                result.Add(new WordInfo
+                {
+                    Text = "が",
+                    DictionaryForm = "が",
+                    NormalizedForm = "が",
+                    PartOfSpeech = PartOfSpeech.Particle,
+                    Reading = "ガ",
+                    StartOffset = gaThief.StartOffset,
+                    EndOffset = gaThief.StartOffset >= 0 ? gaThief.StartOffset + 1 : -1
+                });
+                AddTte(gaThief, wordInfos[i + 1]);
+                i++;
                 changed = true;
                 continue;
             }

--- a/Jiten.Parser/Stages/MorphologicalAnalyser.SplitStages.cs
+++ b/Jiten.Parser/Stages/MorphologicalAnalyser.SplitStages.cs
@@ -585,6 +585,7 @@ public partial class MorphologicalAnalyser
         ("って", "ッテ", PartOfSpeech.Particle, PartOfSpeechSection.AdverbialParticle),
         ("った", "ッタ", PartOfSpeech.Auxiliary, PartOfSpeechSection.None),
         ("わけ", "ワケ", PartOfSpeech.Noun, PartOfSpeechSection.CommonNoun),
+        ("こと", "コト", PartOfSpeech.Noun, PartOfSpeechSection.CommonNoun),
         ("ない", "ナイ", PartOfSpeech.IAdjective, PartOfSpeechSection.PossibleDependant),
         ("から", "カラ", PartOfSpeech.Particle, PartOfSpeechSection.ConjunctionParticle),
         ("けど", "ケド", PartOfSpeech.Particle, PartOfSpeechSection.ConjunctionParticle),
@@ -737,7 +738,7 @@ public partial class MorphologicalAnalyser
                 if (grammarTokens.Count == 0) continue;
                 bool hasLeftoverNoun = grammarTokens.Any(t =>
                     t.PartOfSpeech == PartOfSpeech.Noun && t.PartOfSpeechSection1 == PartOfSpeechSection.CommonNoun &&
-                    t.Text != "わけ");
+                    t.Text is not ("わけ" or "こと"));
                 if (hasLeftoverNoun) continue;
 
                 result[^1] = new WordInfo

--- a/Jiten.Tests/FormSelectionTests.cs
+++ b/Jiten.Tests/FormSelectionTests.cs
@@ -1336,6 +1336,9 @@ public class FormSelectionTests
         yield return ["それでもこのテンションだけは真似できないよ", "真似", 1363740, (byte)0];
         // 私してない = 私 + する, never 私する (わたくしする)
         yield return ["そんな表情、私してない", "してない", 1157170, (byte)1];
+
+        // 総 before a noun (総本部) is the prefix 総(そう) 1401470, not the counter 房総(ふさ) 1519300
+        yield return ["政治総本部と国家保安省が対立しているといっても", "総", 1401470, (byte)0];
     }
 
     public static IEnumerable<object[]> FormSelectionShouldNotMatchCases()

--- a/Jiten.Tests/MorphologicalAnalyserTests.cs
+++ b/Jiten.Tests/MorphologicalAnalyserTests.cs
@@ -580,7 +580,7 @@ public class MorphologicalAnalyserTests
         yield return ["学生さんだって", new[] { "学生", "さん", "だって" }];
         yield return ["ちょっと休憩ーなんて言って", new[] { "ちょっと", "休憩", "なんて", "言って" }];
         yield return ["なんて女だって思われる", new[] { "なんて", "女", "だって", "思われる" }];
-        yield return ["絶対に戻らなきゃいけない", new[] { "絶対", "に", "戻らなきゃ", "いけない" }];
+        yield return ["絶対に戻らなきゃいけない", new[] { "絶対に", "戻らなきゃ", "いけない" }];
         yield return ["とてもいい品が買えました", new[] { "とても", "いい", "品", "が", "買えました" }];
         // JMDict compound noun tests (Mode B refactor)
         // Single JMDict entries - should remain as one token
@@ -1585,6 +1585,28 @@ public class MorphologicalAnalyserTests
         yield return ["大の虫を生かす為に小の虫を殺す。",
             new[] { "大の", "虫", "を", "生かす", "為に", "小", "の", "虫", "を", "殺す" }];
         yield return ["小の虫を殺し得る人物です", new[] { "小", "の", "虫", "を", "殺し", "得る", "人物", "です" }];
+
+        // === batch 4: quotative って / colloquial ねぇ / lexicalized adverbs ===
+        // それっ(interjection homograph)+て re-cut as pronoun それ + quotative って
+        yield return ["そ、それって国家保安省の――", new[] { "それ", "って", "国家", "保安", "省", "の" }];
+        // clause-initial いいか、= Listen! (2555520); 絶対に stays one adverb token
+        yield return ["いいか、絶対に無茶はするなよ。",
+            new[] { "いいか", "絶対に", "無茶", "は", "する", "な", "よ" }];
+        // genuine question いいか never merges
+        yield return ["行っていいか分からない", new[] { "行って", "いい", "か", "分からない" }];
+        // colloquial negative expression: ろくでもねぇ → ろくでもない (2538840)
+        yield return ["......ったく、ろくでもねぇ状況だ", new[] { "ったく", "ろくでもねぇ", "状況", "だ" }];
+        // re-cut quotative って before a noun must not re-merge (なくなったって was dropped entirely)
+        yield return ["いえ、こちらに向かう途中、連絡が取れなくなったって話です。",
+            new[] { "いえ", "こちら", "に", "向かう", "途中", "連絡が取れ", "なくなった", "って", "話", "です" }];
+        // しか may open an expression window: しかねぇ/しかない → 2026790
+        yield return ["やっぱり、このまま進むしかねぇ......!", new[] { "やっぱり", "このまま", "進む", "しかねぇ" }];
+        yield return ["やっぱり、このまま進むしかない", new[] { "やっぱり", "このまま", "進む", "しかない" }];
+        // がる never attaches to a pronoun: 何|がっ|て → 何 + が + って
+        yield return ["あぁ、何がって......?", new[] { "あぁ", "何", "が", "って" }];
+        // 絶対に merges in lattice contexts where Sudachi splits it (consistency with fused form)
+        yield return ["今だって、あたしを気遣うなんて、これまでのあんたなら絶対にしなかった",
+            new[] { "今", "だって", "あたし", "を", "気遣う", "なんて", "これまで", "の", "あんた", "なら", "絶対に", "しなかった" }];
     }
 
     [Theory]

--- a/Jiten.Tests/MorphologicalAnalyserTests.cs
+++ b/Jiten.Tests/MorphologicalAnalyserTests.cs
@@ -1607,6 +1607,24 @@ public class MorphologicalAnalyserTests
         // 絶対に merges in lattice contexts where Sudachi splits it (consistency with fused form)
         yield return ["今だって、あたしを気遣うなんて、これまでのあんたなら絶対にしなかった",
             new[] { "今", "だって", "あたし", "を", "気遣う", "なんて", "これまで", "の", "あんた", "なら", "絶対に", "しなかった" }];
+
+        // === batch 5: quote-initial interjection / OOV tails / elongation / prefix / name theft ===
+        // 信じる split by Sudachi as 信じ+るってことか; OOV-garbage tail re-cut, こと now a grammar token
+        yield return ["これが......これが、信じるってことか。",
+            new[] { "これ", "が", "これ", "が", "信じる", "って", "こと", "か" }];
+        // 山ほど is one lexicalized adverb (Noun+ほど with a JMDict entry)
+        yield return ["やることは山ほどある。", new[] { "やる", "こと", "は", "山ほど", "ある" }];
+        // interjection えっ must not fuse with the standalone adverb そう
+        yield return ["「えっそうだったの？」", new[] { "えっ", "そう", "だった", "の" }];
+        // interjection after a speaker tag + opening quote is utterance-initial → ああ kept, not gated
+        yield return ["【テオドール】「ああ......」", new[] { "テオドール", "ああ" }];
+        // small-vowel elongation れぇぇぇ stripped; れ reattaches to the auxiliary やがる imperative
+        yield return ["早く、ここに来やがれぇぇぇっ!", new[] { "早く", "ここ", "に", "来", "やがれ" }];
+        // katakana mora stolen by 連体詞 あの recut: カティ+アの → カティア + の
+        yield return ["カティアのように振る舞ったら", new[] { "カティア", "の", "ように", "振る舞ったら" }];
+        // 総 before a noun is the prefix (そう), recovered after 総本部 splits to 総 + 本部
+        yield return ["政治総本部と国家保安省が対立しているといっても",
+            new[] { "政治", "総", "本部", "と", "国家", "保安", "省", "が", "対立している", "といっても" }];
     }
 
     [Theory]


### PR DESCRIPTION
Added fixes for the following misparses:

そ、それって国家保安省の――
それって parsing as それっ, should be それ+って

いいか、絶対に無茶はするなよ。
いい+か -> いいか

......ったく、ろくでもねぇ状況だ
ろく+でも+ねぇ -> ろくでもねぇ

いえ、こちらに向かう途中、連絡が取れなくなったって話です。
なくなったって doesn't parse at all

やっぱり、このまま進むしかねぇ......!
しか+ねぇ -> しかねぇ

あぁ、何がって......?
何がって parsing as 何 conjugated with がる, but its actually 何+が+って.

今だって、あたしを気遣うなんて、これまでのあんたなら絶対にしなかった
絶対+に -> 絶対に

Started with a smaller batch to be safe, all misparses now parse as expected and no test regression, other than one older test which assumed 絶対に would split like so: 絶対+に which goes against the premise of one of the fixes. That test was updated to now expect 絶対に.

Went ahead and added some more fixes too:
カティアのように振る舞ったら、それはこの俺の3年間......家族を失ってからの振る舞いすべてを否定することになる。
カティ+アのように -> カティア+のように

「えっそうだったの？」
えっそう -> えっ+そう

早く、ここに来やがれぇぇぇっ!
やが+れ -> やがれ

【テオドール】「ああ......」
ああ doesn't parse at all

これが......これが、信じるってことか。
信じ+るってことか 2nd part doesn't parse at all, should be 信じる+って+こと+か

やることは山ほどある。
山+ほど+山ほど

政治総本部と国家保安省が対立しているといっても、結局あいつはアイリスディーナを監視していることに違いはない。
総 parses as ふさ, should be そう