### PR TITLE
Misparse fixes

### DIFF
--- a/Jiten.Parser/Helpers/MorphologicalAnalyser.RuleData.cs
+++ b/Jiten.Parser/Helpers/MorphologicalAnalyser.RuleData.cs
@@ -23,6 +23,8 @@ public partial class MorphologicalAnalyser
         ("いけす", "か", "ねー", PartOfSpeech.IAdjective),
         ("たら", "し", "たら", PartOfSpeech.Verb),
         ("どう", "あって", "も", PartOfSpeech.Expression),
+        // じゃない+か → じゃないか 2819990 (checked before SpecialCases2 じゃ+ない so the か is absorbed)
+        ("じゃ", "ない", "か", PartOfSpeech.Expression),
     ];
 
     private static readonly HashSet<string> AuxiliaryVerbs =
@@ -215,6 +217,10 @@ public partial class MorphologicalAnalyser
         // CombineTte builds ちゃってぇ with the expressive small-vowel tail; merged back onto なん,
         // the lookup's small-kana strip resolves なんちゃって (matched via CombineFinal, post-tte)
         ("なん", "ちゃってぇ", PartOfSpeech.Expression),
+        // Compound particles / expressions (parallel to に+ついて, に+とって, それ+じゃ above)
+        ("ばかり", "に", PartOfSpeech.Expression), // ばかりに 1010250 "(just) because"
+        ("それ", "では", PartOfSpeech.Conjunction), // それでは 1406050 "well then" (mirrors それじゃ)
+        ("に", "対して", PartOfSpeech.Expression), // に対して 1009800 (mirrors について/にとって)
     ];
 
     private readonly HashSet<char> _sentenceEnders = ['。', '！', '？', '」'];

--- a/Jiten.Parser/Helpers/MorphologicalAnalyser.TextProcessing.cs
+++ b/Jiten.Parser/Helpers/MorphologicalAnalyser.TextProcessing.cs
@@ -166,8 +166,12 @@ public partial class MorphologicalAnalyser
         text = text.Replace("小木曽", $"小木曽{_stopToken}");
         text = text.Replace("するすると", $"{_stopToken}するすると");
         text = text.Replace("ぶっち切", "ぶち切");
-        text = text.Replace("ぶっ壊れ", $"ぶっ{_stopToken}壊れ");
         text = EmphaticTsuRegex().Replace(text, $"{_stopToken}$1");
+        // Split the intensifying prefix ぶっ from 壊れ AFTER EmphaticTsuRegex (脳味噌|が|ぶっ|壊れた).
+        // Doing it before would leave っ in front of the stop token (not the 壊 kanji), so EmphaticTsuRegex
+        // would cut ぶ|っ and Sudachi would merge the preceding が+ぶ→がぶ (then dropped as a kana name).
+        // ぶっ壊れる has no JMDict entry, so ぶっ (2698210) stays a standalone prefix + 壊れた.
+        text = text.Replace("ぶっ壊れ", $"{_stopToken}ぶっ{_stopToken}壊れ");
         text = BanCompoundTsuRegex().Replace(text, $"番{_stopToken}っ");
 
         text = text

--- a/Jiten.Parser/Parser.cs
+++ b/Jiten.Parser/Parser.cs
@@ -1233,10 +1233,16 @@ namespace Jiten.Parser
                             var wordCache = await GetWordsWithCache([preMatchedWordId], batchWordCache);
                             if (wordCache.TryGetValue(preMatchedWordId, out var preMatchedWord))
                             {
-                                var textForReadingLookup = !string.IsNullOrEmpty(wordData.wordInfo.DictionaryForm)
-                                    ? wordData.wordInfo.DictionaryForm
-                                    : wordData.wordInfo.Text;
-                                var readingIndex = GetBestReadingIndex(preMatchedWord, textForReadingLookup, wordData.wordInfo.Reading);
+                                // Prefer the surface for the reading-index lookup so a kana surface (いける)
+                                // resolves to the kana form, even when DictionaryForm was set to a kanji
+                                // homograph purely for cache-keying (disambiguated いける→生ける). Fall back
+                                // to DictionaryForm when the surface itself isn't one of the word's forms,
+                                // so conjugated surfaces (食べた→食べる) still resolve to the lemma's reading.
+                                var surface = wordData.wordInfo.Text;
+                                var readingIndex = GetBestReadingIndex(preMatchedWord, surface, wordData.wordInfo.Reading);
+                                if (readingIndex == 255 && !string.IsNullOrEmpty(wordData.wordInfo.DictionaryForm)
+                                    && wordData.wordInfo.DictionaryForm != surface)
+                                    readingIndex = GetBestReadingIndex(preMatchedWord, wordData.wordInfo.DictionaryForm, wordData.wordInfo.Reading);
                                 processedWord = new DeckWord
                                                 {
                                                     WordId = preMatchedWordId, ReadingIndex = readingIndex,

--- a/Jiten.Parser/Scoring/PriorityOverrides.cs
+++ b/Jiten.Parser/Scoring/PriorityOverrides.cs
@@ -15,6 +15,8 @@ internal static class PriorityOverrides
         1545300, // 妖怪 (ようかい, n) — ghost/yokai, beats 溶解 (dissolution) whose NormalizedForm bonus inflates its score
         1922120, // 兼ねない (かねない, exp/suf) — "might", standalone beats conjugated 兼ねる
         2579880, // コホン/こほん (int) — cough/ahem onomatopoeia, beats 古本 こほん (secondhand book)
+        1571330, // 舐る (ねぶる, uk, vt) — "to lick", beats 眠る's rare ねぶる reading (眠る's normal reading is ねむる)
+        1709300, // 数度 (すうど, n) — "several times", beats JMnedict surname 数度 すどう (Sudachi guesses the name reading)
     ];
 
     private static readonly HashSet<(int WordId, byte ReadingIndex)> FormLevelJitenIds =

--- a/Jiten.Parser/Stages/MorphologicalAnalyser.Disambiguation.cs
+++ b/Jiten.Parser/Stages/MorphologicalAnalyser.Disambiguation.cs
@@ -132,6 +132,12 @@ public partial class MorphologicalAnalyser
             if (word is { Text: "禍", Reading: "カ" })
                 word.Reading = "ワザワイ";
 
+            // 全機 (マサキ given-name reading) → ゼンキ "all aircraft/all units" — the common-noun reading.
+            // Sudachi picks the rare まさき name reading after a leading dash/symbol; the name then wins on
+            // ReadingMatchScore. Correcting the reading (cache key includes Reading) flips it back to 全機 ぜんき.
+            if (word is { Text: "全機", Reading: "マサキ" })
+                word.Reading = "ゼンキ";
+
             // 私 (シ) → ワタシ when standalone — シ reading only in compounds (私的, 私立, 私用)
             if (word is { Text: "私", Reading: "シ" })
             {
@@ -409,6 +415,35 @@ public partial class MorphologicalAnalyser
                 word.NormalizedForm = "行く";
             }
 
+            // いける (kana verb): default to 行ける (1631370 "to be good; go well") — the overwhelmingly
+            // common bare いける. Switch to 生ける (1587190 "to arrange flowers") only with a flower
+            // object nearby (花をいける). Sudachi gives dict=いける for all senses (生ける/活ける/埋ける/
+            // 行ける); the 花 object is the disambiguator.
+            if (word is { Text: "いける", DictionaryForm: "いける" })
+            {
+                var prevTok = i > 0 ? wordInfos[i - 1] : null;
+                var prev2Tok = i >= 2 ? wordInfos[i - 2] : null;
+                bool flowerContext =
+                    (prevTok != null && (prevTok.Text.Contains('花') || prevTok.Text.Contains('華')))
+                    || (prev2Tok != null && (prev2Tok.Text.Contains('花') || prev2Tok.Text.Contains('華')));
+                // Set DictionaryForm too, not just PreMatchedWordId: the DeckWord cache keys on
+                // (Text, POS, DictForm, Reading) and is context-blind, so both senses must produce
+                // distinct cache keys or whichever parses first in a deck wins for all いける.
+                word.PreMatchedWordId = flowerContext ? 1587190 : 1631370;
+                word.DictionaryForm = flowerContext ? "生ける" : "行ける";
+            }
+
+            // ツイてる/ツイてない/ツイてた (katakana ツイ + てる) is the colloquial 付いてる "to be lucky"
+            // (1894260, uk). The grammatical ついて "about" (1854750) is never written in katakana, so the
+            // katakana ツイ head is an unambiguous signal (mirrors the ノリ/セン/イキ katakana rules above).
+            if (word.Text.StartsWith("ツイて", StringComparison.Ordinal))
+            {
+                word.PreMatchedWordId = 1894260;
+                word.DictionaryForm = "ツイてる";
+                if (word.Text.EndsWith("ない", StringComparison.Ordinal))
+                    word.PreMatchedConjugations = ["negative"];
+            }
+
             // 弾ける: Sudachi gives dict=弾ける for both はじける (to burst) and the potential of
             // 弾く/ひく (to play). The reading disambiguates: ヒケ* = 弾く potential, ハジケ* = 弾ける.
             if (word.DictionaryForm == "弾ける" && word.Reading.StartsWith("ヒケ"))
@@ -435,6 +470,18 @@ public partial class MorphologicalAnalyser
                      && word.DictionaryForm == "来る" && word.Reading.StartsWith("キタ"))
             {
                 word.Reading = "ク" + word.Reading[2..];
+            }
+
+            // Clause-initial よって、 is the conjunction 因って "therefore" (1605970), not the te-form
+            // of 依る/因る "to depend on" (1168660). Mid-clause よって (場合によって) keeps the verb.
+            // Setting DictionaryForm too keeps the context-blind DeckWord cache from collapsing both.
+            if (word is { Text: "よって" } && word.DictionaryForm is "依る" or "因る" or "よる"
+                && (i == 0 || wordInfos[i - 1].PartOfSpeech is PartOfSpeech.SupplementarySymbol
+                    or PartOfSpeech.Symbol or PartOfSpeech.BlankSpace)
+                && i + 1 < wordInfos.Count && wordInfos[i + 1].Text is "、" or "，")
+            {
+                word.PreMatchedWordId = 1605970;
+                word.DictionaryForm = "よって";
             }
         }
 

--- a/Jiten.Parser/Stages/MorphologicalAnalyser.RepairStages.cs
+++ b/Jiten.Parser/Stages/MorphologicalAnalyser.RepairStages.cs
@@ -15,6 +15,36 @@ public partial class MorphologicalAnalyser
         {
             var word = wordInfos[i];
 
+            // たか mis-tokenised as the noun 鷹/高 when it's actually past-tense た + question か
+            // (言い過ぎ|たか → 言い過ぎた|か, 飲み過ぎ|たか → 飲み過ぎた|か). Like the たんか repair below
+            // but without the ん. Gated on the preceding token + た forming a real verb past tense, so
+            // genuine 鷹/高 nouns (preceded by を/の, or with no verb stem before) are left alone.
+            if (word is { PartOfSpeech: PartOfSpeech.Noun, Text: "たか" } && result.Count > 0)
+            {
+                var prevTok = result[^1];
+                var pastForms = deconj.Deconjugate(NormalizeToHiragana(prevTok.Text + "た"));
+                bool validPast = pastForms.Any(f =>
+                    f.Process.Any(p => p == "past") &&
+                    f.Tags.Any(t => t.StartsWith("v", StringComparison.Ordinal)));
+                if (validPast)
+                {
+                    result[^1] = new WordInfo(prevTok)
+                    {
+                        Text = prevTok.Text + "た",
+                        PartOfSpeech = PartOfSpeech.Verb,
+                        EndOffset = word.StartOffset >= 0 ? word.StartOffset + 1 : prevTok.EndOffset
+                    };
+                    result.Add(new WordInfo
+                    {
+                        Text = "か", DictionaryForm = "か", NormalizedForm = "か",
+                        PartOfSpeech = PartOfSpeech.Particle, Reading = "カ",
+                        StartOffset = word.StartOffset >= 0 ? word.StartOffset + 1 : -1,
+                        EndOffset = word.EndOffset
+                    });
+                    continue;
+                }
+            }
+
             // Only process たんか noun tokens
             if (word.PartOfSpeech != PartOfSpeech.Noun || word.Text != "たんか")
             {
@@ -935,15 +965,42 @@ public partial class MorphologicalAnalyser
         {
             WordInfo w1 = wordInfos[i];
 
-            // Katakana mora stolen from a name by a following hiragana-dict prenominal: Sudachi
-            // cuts カティア|の as カティ|アの (アの = homograph of 連体詞 あの). A 連体詞 whose dict
-            // form is hiragana but whose surface starts with katakana means the leading mora
-            // belongs to the preceding katakana name — return it and emit the remainder (の) as a
-            // particle. (カティ+ア = カティア, kept as an OOV name token.)
+            // こんな/そんな/あんな/どんな + の: Sudachi cuts the 連体詞 as こん|なの (and the scorer then
+            // mismatches こん to 紺 "navy"). Re-cut to こんな + の when こんな etc. is a real word. Gated on
+            // the 連体詞 POS so the genuine noun reading (色は紺なの "it's navy") is left untouched.
             if (w1.PartOfSpeech == PartOfSpeech.PrenounAdjectival
+                && w1.Text is "こん" or "そん" or "あん" or "どん"
+                && i + 1 < wordInfos.Count && wordInfos[i + 1].Text == "なの"
+                && HasCompoundLookup != null && HasCompoundLookup(w1.Text + "な"))
+            {
+                var nano = wordInfos[i + 1];
+                int naEnd = nano.StartOffset >= 0 ? nano.StartOffset + 1 : w1.EndOffset;
+                newList.Add(new WordInfo(w1)
+                {
+                    Text = w1.Text + "な", DictionaryForm = w1.Text + "な", NormalizedForm = w1.Text + "な",
+                    Reading = w1.Reading + "ナ", EndOffset = naEnd
+                });
+                newList.Add(new WordInfo
+                {
+                    Text = "の", DictionaryForm = "の", NormalizedForm = "の",
+                    PartOfSpeech = PartOfSpeech.Particle, Reading = "ノ",
+                    StartOffset = naEnd, EndOffset = nano.EndOffset
+                });
+                i += 2;
+                continue;
+            }
+
+            // Katakana mora stolen from a name by a following hiragana-dict token: Sudachi cuts
+            // カティア|の as カティ|アの (アの = 連体詞 あの) and カティア|と as カティ|アと (アと = 後 あと).
+            // A token whose dict form is hiragana but whose surface starts with a katakana mora, with
+            // a real particle (の/と/…) as the remainder, means that leading mora belongs to the
+            // preceding katakana name — return it and emit the remainder as a particle.
+            // (カティ+ア = カティア, kept as an OOV name token.)
+            if (w1.PartOfSpeech is PartOfSpeech.PrenounAdjectival or PartOfSpeech.Noun
                 && w1.Text.Length >= 2
                 && IsKatakanaTextChar(w1.Text[0]) && w1.Text[0] != 'ー'
                 && w1.Text[1..].All(c => c is >= '぀' and <= 'ゟ')
+                && CaseParticles.Contains(w1.Text[1..])
                 && KanaConverter.ToHiragana(w1.Text) == w1.DictionaryForm
                 && newList.Count > 0
                 && newList[^1].PartOfSpeech is PartOfSpeech.Noun or PartOfSpeech.Name
@@ -2369,7 +2426,7 @@ public partial class MorphologicalAnalyser
         ["に", "を", "が", "へ", "で", "と", "は", "も", "か", "から", "より", "まで", "の"];
 
     private static readonly HashSet<string> CommonTeFormVerbs =
-        ["なる", "する", "やる", "いる", "ある", "くる", "できる", "おる", "みる", "しまう"];
+        ["なる", "する", "やる", "いる", "ある", "くる", "できる", "おる", "みる", "しまう", "よる"];
 
     // Te-forms of these are いって — the stolen い may only reattach to the previous token when
     // that actually produces a JMDict word (悪|いっ|て → 悪い ✓, ギシギシ|いっ|て → ギシギシい ✗).

--- a/Jiten.Parser/Stages/TokenStage.cs
+++ b/Jiten.Parser/Stages/TokenStage.cs
@@ -100,6 +100,10 @@ internal static class TokenFeatureScanner
                 case "たんか" when w.PartOfSpeech == PartOfSpeech.Noun:
                     f |= TokenFeatures.TextTanka;
                     break;
+                // たか mis-tokenised as 鷹/高 when it's past た + question か (言い過ぎ|たか) — same repair stage
+                case "たか" when w.PartOfSpeech == PartOfSpeech.Noun:
+                    f |= TokenFeatures.TextTanka;
+                    break;
                 case "はさ" when w.PartOfSpeech == PartOfSpeech.Noun:
                     f |= TokenFeatures.TextHasa;
                     break;

--- a/Jiten.Tests/FormSelectionTests.cs
+++ b/Jiten.Tests/FormSelectionTests.cs
@@ -47,6 +47,36 @@ public class FormSelectionTests
         // Pure kana gairaigo: テレビ has only kana forms
         yield return ["テレビ", "テレビ", 1080510, (byte)0];
 
+        // 舐る (ねぶる, lick, uk) should beat 眠る's rare ねぶる reading (眠る's normal reading is ねむる)
+        yield return ["その部分を舌先で探りながら、丁寧にねぶっていく。", "ねぶっていく", 1571330, (byte)2];
+
+        // 数度 (すうど "several times") should beat the JMnedict surname 数度 (すどう)
+        yield return ["東ドイツに派遣されたのは昨年末で、それから数度、掃討任務に参加している。", "数度", 1709300, (byte)0];
+
+        // いける defaults to 行ける (go well); 生ける (arrange flowers) only with a flower object nearby.
+        // Kana surface いける resolves to each word's kana form (行ける ri1 / 生ける ri2), not the kanji.
+        yield return ["......いけると思います。", "いける", 1631370, (byte)1];
+        yield return ["花をいける", "いける", 1587190, (byte)2];
+
+        // katakana ツイてない is 付いてる/ツイてる "to be lucky" (1894260), not ついて "about" (1854750)
+        yield return ["“ツイてない”なんて言っちゃダメ", "ツイてない", 1894260, (byte)4];
+
+        // に対して in the full sentence (preceding clauses present) — mirrors について/にとって
+        yield return ["イングヒルトだけじゃない、これまで見捨ててきた衛士たち全員に対して、俺はそう言えるのか......。", "に対して", 1009800, (byte)0];
+
+        // 脳味噌がぶっ壊れた in the full sentence: が (case particle) and ぶっ (prefix) must both survive
+        yield return ["「同じ部隊の隊員なら、脳味噌がぶっ壊れた奴とでも運命を共にしろというのか!?――それこそ無駄死にだッ!」", "が", 2028930, (byte)0];
+        yield return ["「同じ部隊の隊員なら、脳味噌がぶっ壊れた奴とでも運命を共にしろというのか!?――それこそ無駄死にだッ!」", "ぶっ", 2698210, (byte)1];
+
+        // clause-initial よって、 is the conjunction 因って "therefore" (1605970), not 依る te-form (1168660).
+        // Full sentence (with 「) is the regression case: the leading quote+space made RepairQuotativeTte
+        // split よっ|て → よ|って before the fix.
+        yield return ["「よって、ここで慈悲の一撃を加える」", "よって", 1605970, (byte)5];
+
+        // 全機 → ぜんき "all aircraft" (2860335), not the まさき given name (5470930). A leading dash makes
+        // Sudachi pick the マサキ name reading, so the full sentence (with ――) is the regression case.
+        yield return ["――全機、跳躍開始!", "全機", 2860335, (byte)0];
+
         // 食べている should resolve to 食べる (1358280)
         yield return ["食べている", "食べている", 1358280, (byte)0];
 

--- a/Jiten.Tests/MorphologicalAnalyserTests.cs
+++ b/Jiten.Tests/MorphologicalAnalyserTests.cs
@@ -39,6 +39,18 @@ public class MorphologicalAnalyserTests
 
     public static IEnumerable<object[]> SegmentationCases()
     {
+        // Compound particles / expressions that Sudachi splits — complete sentences as provided
+        yield return ["私が油断したばかりに......", new[] { "私", "が", "油断した", "ばかりに" }];
+        yield return ["......なかなか威勢のいいお仲間じゃないか", new[] { "なかなか", "威勢のいい", "お", "仲間", "じゃないか" }];
+        yield return ["しかし、それでは――", new[] { "しかし", "それでは" }];
+        // たか mis-tokenised as 鷹/高 — should be past た + question か
+        yield return ["......言い過ぎたか?", new[] { "言い過ぎた", "か" }];
+        // こんな 連体詞 cut as こん|なの (こん mismatched to 紺) — should be こんな + の
+        yield return ["こんなの、取っておく価値あるのか?", new[] { "こんな", "の", "取っておく", "価値", "ある", "の", "か" }];
+        // katakana name mora stolen by a following particle: カティア|と cut as カティ|アと (アと=後 あと)
+        yield return ["必ず、カティアとファム姉を助け出そう。",
+            new[] { "必ず", "カティア", "と", "ファム", "姉", "を", "助け出そう" }];
+
         yield return ["ご注文はうさぎですか", new[] { "ご注文", "は", "うさぎ", "ですか" }];
         yield return ["しませんか", new[] { "しません", "か" }];
         yield return ["ドンマイ", new[] { "ドンマイ" }];


### PR DESCRIPTION
Fixes for some misparses:

私が油断したばかりに......
ばかり+に -> ばかりに

......なかなか威勢のいいお仲間じゃないか
じゃない+か -> じゃないか

しかし、それでは――
それ+では -> それでは

必ず、カティアとファム姉を助け出そう。
カティ+アと -> カティア+と.

イングヒルトだけじゃない、これまで見捨ててきた衛士たち全員に対して、俺はそう言えるのか......。
に+対して -> に対して
Note: Originally planned to merge の+か -> のか but that interfered with existing code that had to do with のかもしれません or something along those lines, I believe. So I left it be.

その部分を舌先で探りながら、丁寧にねぶっていく。
ねぶって should parse to ねぶる (to lick) not (to sleep)

......言い過ぎたか?
言い過ぎ+たか -> 言い過ぎた+か

“ツイてない”なんて言っちゃダメ
ツイてない should be ツイてる not ついて

こんなの、取っておく価値あるのか?
こん+なの -> こんな+の

......いけると思います。
いける parsing as "to  plant", should be "to go well"

東ドイツに派遣されたのは昨年末で、それから数度、掃討任務に参加している。
数度 parsing as すどう (a name), should be すうど(several times)

「よって、ここで慈悲の一撃を加える」
よ+って -> よって (therefore)

「同じ部隊の隊員なら、脳味噌がぶっ壊れた奴とでも運命を共にしろというのか!?――それこそ無駄死にだッ!」
が and ぶっ don't parse

――全機、跳躍開始!
全機 parsing as まさき (name) not ぜんき (all machines/planes)

Main things to note:
- The いける fix is very opinionated, and by no means perfect. It biases kana いける "to go well" which is from my observation the most common usage, and looks back to check for 花/華 to see if it should be "to arrange flowers" instead. This leaves out 埋ける "to bury" for example, but that I would imagine is very unlikely to show up in kana. いける is a heavily misparsed word so I figured it was worthwhile.
- 全機 / 数度: These could legitimately be names, so having them bias to the non-name meanings is an opinionated choice. As far as I can tell every parse of 全機(まさき) is a misparse on jiten in the example sentences so seems a safe one. Something to be considered could be weighing non-name words heavier than they are now versus same-kanji names, but I've not looked into that.
- In Parser.cs, previously the readingIndex lookup used the dictionary form before the actual text, which would (at least in いける's case) result in displaying the wrong form (the kanji one) when the kana one was used. This was updated to use the text first and then try the dictionary form for GetBestReading.

No test regressions.
