### PR TITLE
Address って parsing issues

### DIFF
--- a/Jiten.Parser/Misparse/MisparseGates.cs
+++ b/Jiten.Parser/Misparse/MisparseGates.cs
@@ -150,7 +150,10 @@ internal static class MisparseGates
 
     private static bool IsGrammaticalFollower(string text)
         => text is "が" or "を" or "に" or "は" or "の" or "で" or "と" or "へ"
-           or "から" or "まで" or "より" or "も" or "って" or "だ" or "です";
+               or "から" or "まで" or "より" or "も" or "って" or "だ" or "です"
+           // Quotative って-clusters (っていう, ってのは, …) justify a short-kana verb being quoted
+           // (してある+っていう), the same way a bare って does — they only differ by a later merge.
+           || text.StartsWith("って", StringComparison.Ordinal);
 
     public static (bool isUsuallyKana, bool hasKanjiSpelling, bool readingIsIchi) GetWordFlags(
         JmDictWord? word, byte readingIndex)

--- a/Jiten.Parser/Stages/MorphologicalAnalyser.CombineStages.cs
+++ b/Jiten.Parser/Stages/MorphologicalAnalyser.CombineStages.cs
@@ -347,8 +347,11 @@ public partial class MorphologicalAnalyser
         // って re-cut as quotative (DictionaryForm って, vs て for a real te-particle) stays split
         // when followed by a quote-taking verb (かな+って+思ったら). Otherwise allow the re-merge —
         // an auxiliary continuation (つか+って+ください, かな+って+いる) proves the re-cut wrong.
+        // Both kanji and kana dictionary forms are listed: Sudachi tags 言う as the kana いう just as
+        // often (寄ってくる+って+いう → keep くる|って split, never くる+って glued into a blob).
         if (nextWord is { Text: "って", DictionaryForm: "って" } && i + 2 < wordInfos.Count &&
-            wordInfos[i + 2].DictionaryForm is "思う" or "言う" or "聞く" or "考える" or "感じる")
+            wordInfos[i + 2].DictionaryForm is "思う" or "おもう" or "言う" or "いう"
+                or "聞く" or "きく" or "考える" or "感じる")
             return true;
 
         // Re-cut って before a noun (なくなった+って+話), punctuation, or sentence end is the
@@ -359,6 +362,14 @@ public partial class MorphologicalAnalyser
             (i + 2 >= wordInfos.Count ||
              wordInfos[i + 2].PartOfSpeech is PartOfSpeech.Noun or PartOfSpeech.CommonNoun
                  or PartOfSpeech.SupplementarySymbol))
+            return true;
+
+        // Re-cut って before a sentence-ending particle (待つ+って+さ, 行く+って+よ/ね/わ) is the
+        // quotative — a te-form continuation needs a verb/auxiliary after it, never a final particle.
+        // Without this the verb re-absorbs って into an unresolvable blob (待つって).
+        if (nextWord is { Text: "って", DictionaryForm: "って" } && i + 2 < wordInfos.Count
+            && wordInfos[i + 2] is { PartOfSpeech: PartOfSpeech.Particle }
+            && wordInfos[i + 2].Text is "さ" or "よ" or "ね" or "わ" or "ぞ" or "ぜ")
             return true;
 
         // Benefactive auxiliaries after a te-form stay separate tokens (堪能させて|いただきます,
@@ -570,6 +581,46 @@ public partial class MorphologicalAnalyser
         if (newList == null) return wordInfos;
         newList.Add(currentWord);
         return newList;
+    }
+
+    // Quotative って + the kana verb いう fuse into the single relativiser っていう (= という,
+    // JMDict 2757880), matching how ってのは/たって already surface as one cluster. Restricted to the
+    // kana dictionary form いう: the kanji 言う is the lexical verb "to say" (だって|言う|人) and stays
+    // split. A conjugated いう (いって/いった) is a real verb form and is likewise left alone.
+    private List<WordInfo> CombineQuotativeToIu(List<WordInfo> wordInfos)
+    {
+        if (wordInfos.Count < 2)
+            return wordInfos;
+
+        List<WordInfo>? newList = null;
+
+        for (int i = 0; i < wordInfos.Count; i++)
+        {
+            var word = wordInfos[i];
+
+            if (i + 1 < wordInfos.Count
+                && word is { Text: "って", DictionaryForm: "って", PartOfSpeech: PartOfSpeech.Particle }
+                && wordInfos[i + 1] is { Text: "いう", DictionaryForm: "いう" })
+            {
+                newList ??= [..wordInfos[..i]];
+                var iu = wordInfos[i + 1];
+                newList.Add(new WordInfo(word)
+                {
+                    Text = "っていう",
+                    DictionaryForm = "っていう",
+                    NormalizedForm = "っていう",
+                    Reading = "ッテイウ",
+                    PartOfSpeech = PartOfSpeech.Conjunction,
+                    EndOffset = iu.EndOffset
+                });
+                i++;
+                continue;
+            }
+
+            newList?.Add(word);
+        }
+
+        return newList ?? wordInfos;
     }
 
     private List<WordInfo> CombineVerbDependant(List<WordInfo> wordInfos)

--- a/Jiten.Parser/Stages/MorphologicalAnalyser.Pipeline.cs
+++ b/Jiten.Parser/Stages/MorphologicalAnalyser.Pipeline.cs
@@ -51,6 +51,7 @@ public partial class MorphologicalAnalyser
         Stage(TokenStageGroup.Combine, CombineAdverbialParticle, TokenFeatures.AdvParticle),
         Stage(TokenStageGroup.Combine, CombineVerbDependant),
         Stage(TokenStageGroup.Combine, CombineParticles),
+        Stage(TokenStageGroup.Combine, CombineQuotativeToIu),
         Stage(TokenStageGroup.Combine, CombineFinal),
         Stage(TokenStageGroup.Split, SplitUnresolvableSuruCompounds),
         Stage(TokenStageGroup.Repair, RepairTankaToTaNKa, TokenFeatures.TextTanka),

--- a/Jiten.Parser/Stages/MorphologicalAnalyser.RepairStages.cs
+++ b/Jiten.Parser/Stages/MorphologicalAnalyser.RepairStages.cs
@@ -2504,6 +2504,17 @@ public partial class MorphologicalAnalyser
             });
         }
 
+        // A stranded-mora reattachment counts as a real verb when it is a dictionary-form godan/
+        // ichidan verb (in JMDict, う-row ending) or deconjugates one step to an imperative/
+        // volitional (従え → 従う). The う-row ending rejects noun fragments the deconjugator
+        // over-tags (はだ/んだ "deconjugate" to verb pasts but never end う-row).
+        bool IsVerbReattachment(string s) =>
+            (s.Length >= 2
+                && s[^1] is 'う' or 'く' or 'ぐ' or 'す' or 'つ' or 'ぬ' or 'ぶ' or 'む' or 'る'
+                && HasNonNameCompoundLookup?.Invoke(s) == true
+                && DeconjugatesToVerb(s))
+            || MergesToFinalForm(s);
+
         for (int i = 0; i < wordInfos.Count; i++)
         {
             // Fused variant of the katakana-mora theft: Sudachi emits a single Xって token
@@ -2586,6 +2597,127 @@ public partial class MorphologicalAnalyser
                     EndOffset = gaThief.StartOffset >= 0 ? gaThief.StartOffset + 1 : -1
                 });
                 AddTte(gaThief, wordInfos[i + 1]);
+                i++;
+                changed = true;
+                continue;
+            }
+
+            // Sudachi strands a verb's final mora on a thief token ending っ, mis-tagging the thief
+            // as an interjection/adverb/auxiliary/verb: 読|むっ|て, 泳|ぐっ|て, 行|くっ|て, 待|つっ|て,
+            // 話|すっ|て, 従|えっ|て. The thief's POS guess is noise — the reliable signal is that the
+            // stranded mora reattaches to the preceding stem to make a real verb, its dictionary form
+            // (読む) or a one-step imperative/volitional (従え, 殴り合え). Prefer folding a 連用形 stem +
+            // suffix (殴り+合) over the lone previous token. A genuine interjection (あっ|て) leaves no
+            // verb behind it and is left untouched.
+            if (i + 1 < wordInfos.Count
+                && wordInfos[i].Text.Length == 2
+                && wordInfos[i].Text[^1] == 'っ'
+                && wordInfos[i].Text[0] is >= 'ぁ' and <= 'ゖ'
+                && wordInfos[i + 1].Text == "て"
+                && wordInfos[i].PartOfSpeech is not (PartOfSpeech.Particle or PartOfSpeech.Pronoun)
+                && result.Count > 0)
+            {
+                var thiefMora = wordInfos[i].Text[0];
+
+                int stemBack = 0;
+                if (result.Count >= 2 && result[^1].PartOfSpeech == PartOfSpeech.Suffix
+                    && IsVerbReattachment(result[^2].Text + result[^1].Text + thiefMora))
+                    stemBack = 2;
+                else if (result[^1].PartOfSpeech is PartOfSpeech.Noun or PartOfSpeech.CommonNoun
+                             or PartOfSpeech.Verb or PartOfSpeech.Prefix or PartOfSpeech.Suffix
+                         && IsVerbReattachment(result[^1].Text + thiefMora))
+                    stemBack = 1;
+
+                if (stemBack > 0)
+                {
+                    var moraThief = wordInfos[i];
+                    var stemHead = result[result.Count - stemBack];
+                    var verbText = "";
+                    for (int k = result.Count - stemBack; k < result.Count; k++) verbText += result[k].Text;
+                    verbText += thiefMora;
+                    result.RemoveRange(result.Count - stemBack, stemBack);
+                    result.Add(new WordInfo(stemHead)
+                    {
+                        Text = verbText,
+                        DictionaryForm = verbText,
+                        NormalizedForm = verbText,
+                        PartOfSpeech = PartOfSpeech.Verb,
+                        EndOffset = moraThief.StartOffset >= 0 ? moraThief.StartOffset + 1 : -1
+                    });
+                    AddTte(moraThief, wordInfos[i + 1]);
+                    i++;
+                    changed = true;
+                    continue;
+                }
+            }
+
+            // Sudachi splits a compound noun whose final kanji absorbs って's っ into a real-but-
+            // here-wrong verb te-form (自意識 → 自|意|識っ[識る], 認識 → 認|識っ; 識る "to know" is a
+            // genuine verb, just not the reading inside a noun compound). That reading breaks the
+            // noun run so the lookup's compound matcher can't reform 自意識. Hand the stolen っ back to
+            // って and re-tag the kanji as a noun, so the matcher reforms the compound and っていう
+            // clusters. Gated on the kanji plus its preceding kanji compound-part(s) — Noun/Suffix/
+            // Prefix, e.g. the 接尾辞 認 — forming a real JMDict compound noun. A genuine 識る takes a
+            // particle object (真実を識って), so its predecessor is never a bare kanji and it is left alone.
+            if (i + 1 < wordInfos.Count
+                && wordInfos[i] is { PartOfSpeech: PartOfSpeech.Verb }
+                && wordInfos[i].Text.Length == 2
+                && wordInfos[i].Text[^1] == 'っ'
+                && wordInfos[i].Text[0] is >= '一' and <= '鿿'
+                && wordInfos[i + 1].Text == "て"
+                && result.Count > 0
+                && result[^1].PartOfSpeech is PartOfSpeech.Noun or PartOfSpeech.CommonNoun
+                    or PartOfSpeech.Suffix or PartOfSpeech.Prefix
+                && result[^1].Text[^1] is >= '一' and <= '鿿')
+            {
+                var kanjiThief = wordInfos[i];
+                var tailKanji = kanjiThief.Text[..^1];
+                bool formsNoun =
+                    HasNonNameCompoundLookup?.Invoke(result[^1].Text + tailKanji) == true
+                    || (result.Count >= 2
+                        && result[^2].PartOfSpeech is PartOfSpeech.Noun or PartOfSpeech.CommonNoun
+                            or PartOfSpeech.Suffix or PartOfSpeech.Prefix
+                        && result[^2].Text[^1] is >= '一' and <= '鿿'
+                        && HasNonNameCompoundLookup?.Invoke(result[^2].Text + result[^1].Text + tailKanji) == true);
+
+                if (formsNoun)
+                {
+                    result.Add(new WordInfo(kanjiThief)
+                    {
+                        Text = tailKanji,
+                        DictionaryForm = tailKanji,
+                        NormalizedForm = tailKanji,
+                        PartOfSpeech = PartOfSpeech.Noun,
+                        EndOffset = kanjiThief.StartOffset >= 0 ? kanjiThief.StartOffset + 1 : -1
+                    });
+                    AddTte(kanjiThief, wordInfos[i + 1]);
+                    i++;
+                    changed = true;
+                    continue;
+                }
+            }
+
+            // 達 (たち) mis-split by Sudachi as past-た + ちう-auxiliary before a quotative って:
+            // 貴方|た|ちっ|て → 貴方 + たち + って. A pronoun/noun cannot take the past auxiliary た,
+            // so this sequence is only ever the pluralising suffix 達 followed by quotative って.
+            if (i + 1 < wordInfos.Count
+                && wordInfos[i] is { Text: "ちっ", PartOfSpeech: PartOfSpeech.Auxiliary, DictionaryForm: "ちう" }
+                && wordInfos[i + 1].Text == "て"
+                && result.Count >= 2
+                && result[^1] is { Text: "た", PartOfSpeech: PartOfSpeech.Auxiliary }
+                && result[^2].PartOfSpeech is PartOfSpeech.Pronoun or PartOfSpeech.Noun or PartOfSpeech.CommonNoun)
+            {
+                var chiThief = wordInfos[i];
+                result[^1] = new WordInfo(result[^1])
+                {
+                    Text = "たち",
+                    DictionaryForm = "たち",
+                    NormalizedForm = "達",
+                    Reading = "タチ",
+                    PartOfSpeech = PartOfSpeech.Suffix,
+                    EndOffset = chiThief.StartOffset >= 0 ? chiThief.StartOffset + 1 : -1
+                };
+                AddTte(chiThief, wordInfos[i + 1]);
                 i++;
                 changed = true;
                 continue;
@@ -2760,6 +2892,14 @@ public partial class MorphologicalAnalyser
                     {
                         var forms = deconj.Deconjugate(stripped);
                         shouldRepair = forms.Count > 0;
+                    }
+                    // A thief Sudachi mis-tags as an adverb but whose stripped form is itself a
+                    // dictionary verb is the same stem theft one mora wider (するっ|て → する + って,
+                    // from 勉強するっていう). The う-row gate in IsVerbReattachment rejects noun
+                    // homographs the deconjugator over-tags (ことっ → こと=事 stays a noun).
+                    else if (IsVerbReattachment(stripped))
+                    {
+                        shouldRepair = true;
                     }
                 }
             }

--- a/Jiten.Parser/Stages/MorphologicalAnalyser.SplitStages.cs
+++ b/Jiten.Parser/Stages/MorphologicalAnalyser.SplitStages.cs
@@ -589,6 +589,8 @@ public partial class MorphologicalAnalyser
         ("ない", "ナイ", PartOfSpeech.IAdjective, PartOfSpeechSection.PossibleDependant),
         ("から", "カラ", PartOfSpeech.Particle, PartOfSpeechSection.ConjunctionParticle),
         ("けど", "ケド", PartOfSpeech.Particle, PartOfSpeechSection.ConjunctionParticle),
+        ("だけ", "ダケ", PartOfSpeech.Particle, PartOfSpeechSection.AdverbialParticle),
+        ("でも", "デモ", PartOfSpeech.Particle, PartOfSpeechSection.AdverbialParticle),
         ("の", "ノ", PartOfSpeech.Particle, PartOfSpeechSection.CaseMarkingParticle),
         ("は", "ハ", PartOfSpeech.Particle, PartOfSpeechSection.BindingParticle),
         ("が", "ガ", PartOfSpeech.Particle, PartOfSpeechSection.CaseMarkingParticle),
@@ -600,6 +602,10 @@ public partial class MorphologicalAnalyser
         ("か", "カ", PartOfSpeech.Particle, PartOfSpeechSection.AdverbialParticle),
         ("だ", "ダ", PartOfSpeech.Auxiliary, PartOfSpeechSection.None),
         ("な", "ナ", PartOfSpeech.Particle, PartOfSpeechSection.SentenceEndingParticle),
+        ("ね", "ネ", PartOfSpeech.Particle, PartOfSpeechSection.SentenceEndingParticle),
+        ("よ", "ヨ", PartOfSpeech.Particle, PartOfSpeechSection.SentenceEndingParticle),
+        ("さ", "サ", PartOfSpeech.Particle, PartOfSpeechSection.SentenceEndingParticle),
+        ("わ", "ワ", PartOfSpeech.Particle, PartOfSpeechSection.SentenceEndingParticle),
         ("ん", "ン", PartOfSpeech.Particle, PartOfSpeechSection.Juntaijoushi),
         ("た", "タ", PartOfSpeech.Auxiliary, PartOfSpeechSection.None),
     ];
@@ -611,9 +617,21 @@ public partial class MorphologicalAnalyser
         return text.Length > 0;
     }
 
+    private static bool DeconjugatesToVerb(string hiragana)
+    {
+        foreach (var f in Deconjugator.Instance.Deconjugate(hiragana))
+            foreach (var t in f.Tags)
+                if (t.StartsWith("v", StringComparison.Ordinal))
+                    return true;
+        return false;
+    }
+
     private static bool IsLikelyOovGarbage(WordInfo w)
     {
-        if (w.Text.Length < 4) return false;
+        // Length 3 admits the minimal stem-mora-theft blob (る+って → なる|って), where Sudachi
+        // strands the verb's final mora onto a bare quotative って. The split is still tightly
+        // gated downstream (prev+prefix must deconjugate to a real verb/adjective).
+        if (w.Text.Length < 3) return false;
         if (w.PartOfSpeech is not (PartOfSpeech.Noun or PartOfSpeech.CommonNoun or PartOfSpeech.Interjection or PartOfSpeech.Filler))
             return false;
         if (!IsAllHiraganaSpan(w.Text.AsSpan())) return false;
@@ -626,31 +644,61 @@ public partial class MorphologicalAnalyser
         return false;
     }
 
-    private static List<WordInfo> TokenizeGrammarRemainder(string text, int startOffset)
+    private List<WordInfo> TokenizeGrammarRemainder(string text, int startOffset)
     {
         var tokens = new List<WordInfo>();
         int i = 0;
         while (i < text.Length)
         {
-            bool matched = false;
+            int markerLen = 0;
+            (string reading, PartOfSpeech pos, PartOfSpeechSection sec) marker = default;
             foreach (var (gram, reading, pos, sec) in GrammarTokenTable)
-            {
-                if (text.AsSpan(i).StartsWith(gram))
+                if (gram.Length > markerLen && text.AsSpan(i).StartsWith(gram))
+                    (markerLen, marker) = (gram.Length, (reading, pos, sec));
+
+            // Pull a trailing content VERB out of the cluster (って+いう, ってのは+わかる) instead of
+            // dumping it as one OOV noun that aborts the whole split. Restricted to dictionary-form
+            // verbs on purpose: matching arbitrary short tails mis-cuts grammatical clusters
+            // (のはだな → の|肌|な, ってんだ → って|んだ). The candidate must end in a う-row kana — the
+            // deconjugator alone over-generates (んだ/はだ both "deconjugate" to verb pasts).
+            int verbLen = 0;
+            if (HasNonNameCompoundLookup != null)
+                for (int len = Math.Min(text.Length - i, 6); len > markerLen && len >= 2; len--)
                 {
-                    tokens.Add(new WordInfo
-                    {
-                        Text = gram, DictionaryForm = gram, NormalizedForm = gram, Reading = reading,
-                        PartOfSpeech = pos, PartOfSpeechSection1 = sec,
-                        StartOffset = startOffset >= 0 ? startOffset + i : -1,
-                        EndOffset = startOffset >= 0 ? startOffset + i + gram.Length : -1
-                    });
-                    i += gram.Length;
-                    matched = true;
+                    var cand = text.Substring(i, len);
+                    if (cand[^1] is not ('う' or 'く' or 'ぐ' or 'す' or 'つ' or 'ぬ' or 'ぶ' or 'む' or 'る')) continue;
+                    if (!HasNonNameCompoundLookup(cand)) continue;
+                    if (!DeconjugatesToVerb(cand)) continue;
+                    verbLen = len;
                     break;
                 }
+
+            if (verbLen > 0)
+            {
+                var w = text.Substring(i, verbLen);
+                tokens.Add(new WordInfo
+                {
+                    Text = w, DictionaryForm = w, NormalizedForm = w,
+                    Reading = WanaKanaShaapu.WanaKana.ToKatakana(NormalizeToHiragana(w)),
+                    PartOfSpeech = PartOfSpeech.Verb,
+                    StartOffset = startOffset >= 0 ? startOffset + i : -1,
+                    EndOffset = startOffset >= 0 ? startOffset + i + verbLen : -1
+                });
+                i += verbLen;
+                continue;
             }
 
-            if (!matched) break;
+            if (markerLen == 0) break;
+
+            var gramText = text.Substring(i, markerLen);
+            tokens.Add(new WordInfo
+            {
+                Text = gramText, DictionaryForm = gramText, NormalizedForm = gramText, Reading = marker.reading,
+                PartOfSpeech = marker.pos, PartOfSpeechSection1 = marker.sec,
+                StartOffset = startOffset >= 0 ? startOffset + i : -1,
+                EndOffset = startOffset >= 0 ? startOffset + i + markerLen : -1
+            });
+            i += markerLen;
         }
 
         if (i < text.Length)

--- a/Jiten.Parser/Stages/TokenStage.cs
+++ b/Jiten.Parser/Stages/TokenStage.cs
@@ -124,7 +124,7 @@ internal static class TokenFeatureScanner
                     break;
             }
 
-            if (w.Text.Length >= 4
+            if (w.Text.Length >= 3
                 && w.PartOfSpeech is PartOfSpeech.Noun or PartOfSpeech.CommonNoun or PartOfSpeech.Interjection or PartOfSpeech.Filler
                 && (f & TokenFeatures.OovGarbage) == 0)
             {

--- a/Jiten.Tests/MorphologicalAnalyserTests.cs
+++ b/Jiten.Tests/MorphologicalAnalyserTests.cs
@@ -326,6 +326,31 @@ public class MorphologicalAnalyserTests
             "てか最近ファン層は円盤すら買わないからそいつらから金とるってのは無謀",
             new[] { "てか", "最近", "ファン層", "は", "円盤", "すら", "買わない", "から", "そいつら", "から", "金", "とる", "ってのは", "無謀" }
         ];
+        // Quotative って where Sudachi strands the preceding verb's final mora onto an OOV って-blob
+        // (なる→な+るって) or an interjection (従→従+えっ+て): the verb must be rescued whole and って
+        // kept as a particle, never dropped as an unresolvable blob.
+        yield return ["貴方たちって民主主義を否定する", new[] { "貴方", "たち", "って", "民主主義", "を", "否定する" }];
+        yield return ["展開されているっていうのは", new[] { "展開されて", "いる", "っていう", "の", "は" }];
+        yield return ["ようにしてあるっていうだけでも", new[] { "ようにして", "ある", "っていう", "だけ", "でも" }];
+        yield return ["お嫁さんになるって約束した", new[] { "お嫁さん", "に", "なる", "って", "約束した" }];
+        yield return ["癇に障るってのはわかる", new[] { "癇に障る", "ってのは", "わかる" }];
+        yield return ["指示に従えってことか", new[] { "指示", "に", "従え", "って", "こと", "か" }];
+        yield return ["殴り合えってわけだな", new[] { "殴り合え", "って", "わけ", "だ", "な" }];
+        yield return ["寄ってくるっていう話", new[] { "寄って", "くる", "っていう", "話" }];
+        // Godan verbs whose final mora Sudachi strands onto the って thief (mis-tagged
+        // interjection/adverb/auxiliary): the verb must be reconstituted, not dropped.
+        yield return ["読むって約束した", new[] { "読む", "って", "約束した" }];
+        yield return ["泳ぐって言うの", new[] { "泳ぐ", "って", "言う", "の" }];
+        yield return ["話すってことか", new[] { "話す", "って", "こと", "か" }];
+        // って before a sentence-ending particle is the quotative, not a te-form (待つって blob).
+        yield return ["待つってさ", new[] { "待つ", "って", "さ" }];
+        yield return ["やめるってね", new[] { "やめる", "って", "ね" }];
+        // って + kana いう fuses into the relativiser っていう (= という), like ってのは.
+        yield return ["行くっていう話", new[] { "行く", "っていう", "話" }];
+        // Compound noun whose final kanji Sudachi steals into a verb te-form before って
+        // (自意識 → 自|意|識っ[識る]): de-verbed so the compound matcher reforms 自意識 and っていう clusters.
+        yield return ["自意識っていうのがない", new[] { "自意識", "っていう", "の", "が", "ない" }];
+        yield return ["認識っていう", new[] { "認識", "っていう" }];
         yield return ["とろいな", new[] { "とろい", "な" }];
         yield return ["なんでもかんでも", new[] { "なんでもかんでも" }];
         yield return ["しないかい", new[] { "しない", "かい" }];


### PR DESCRIPTION
This addresses recent noticed issues with って , primarily it getting combined with part of the word before it often creating either an unparsed mess or parsing to the incorrect word. Sudachi was deciding to split things in a way that made ってs  attach backwards rather aggressively, so this goes through and corrects things.

Specifically the following are reference for what was corrected:

あれ、違うの?貴方たちって民主主義を否定して、共産党の独裁を喜んで受け入れているんでしょう?
たちって -> たち+って

それも一個中隊分どころか......数えるのも嫌になるほど展開されているっていうのは、な......。
展開されてい+るっていうのは -> 展開されて+いる+っていう+の+は

戦術機の整備施設を丸ごと一式、運搬できるようにしてあるっていうだけでも、呆れ返る話なんだが。
ように+してあ+るっていうだけでも -> ようにして+ある+っていう+だけ+でも

私、お兄ちゃんのお嫁さんになるって、昔、約束したじゃない!
な+るって -> なる+って

嫌いな奴の言葉は癇に障るってのはわかる。
癇+に+障+るってのはわかる -> 癇に障る+ってのは+わかる

......戦闘中も黙って指示に従えってことか?
従+えって -> 従え+って

遠慮なくBETAと真正面から殴り合えってわけだな。光線級吶喊よりはマシかもしれないが、この編制でそれをやるのか......。
殴り合+えって -> 殴り合え+って

BETAは軍の集結地に寄ってくるっていう話......理屈は不明だが嘘じゃない気がする。
寄ってくるって+いう -> 寄って+くる+っていう

というか、こいつ、ひょっとしたら自意識っていうのが、あんまりないのかもしれないな……。
自+意+識って+いう -> 自意識+っていう

As you can see in all of these って is grabbing onto what comes before in an incorrect manner.

No regressions.