### PR TITLE
Fix for new SRS batch review timer issue

### DIFF
--- a/Jiten.Web/app/composables/useStudyTimer.ts
+++ b/Jiten.Web/app/composables/useStudyTimer.ts
@@ -318,6 +318,16 @@ export function useStudyTimer(cb: StudyTimerCallbacks) {
     startPhase();
   });
 
+  // Restart the countdown when a card reappears after the queue drained. Finishing a batch advances
+  // the cursor past the end (currentCard → null, timer parked at idle); the next batch's first card
+  // then arrives asynchronously from fetchBatch. The cardShownAt/isFlipped watcher above does not
+  // restart across that null → card refill, so without this the first card of each new batch is left
+  // with no timer. Keying off the current card's identity catches the reappearance the timestamp
+  // watcher misses. (Mirrors scheduleAutoRestart, which backstops the same gap after auto-grades.)
+  watch(() => store.currentCard, (card, prev) => {
+    if (card && !prev && phase.value === 'idle') startPhase();
+  });
+
   watch(cb.active, (on) => {
     if (!on) manualPaused.value = false; // a fresh activation shouldn't inherit a stale pause
     startPhase();


### PR DESCRIPTION
A user reported that in the SRS, if the review timer was enabled, often times when a new batch of cards starts the review timer doesn't start for the first card.

This adds a simple check for that situation, to get the timer going again if it isn't started on a new batch.

Personally tested both on the live site and locally, encountered the issue in both places. After the fix, no issues locally.

(One user noted they saw this issue as a feature though).

Ignore the history :smiley: 