### PR TITLE
Add an end of SRS batch checkpoint dialog

### DIFF
--- a/Jiten.Api/Dtos/StudySettingsDto.cs
+++ b/Jiten.Api/Dtos/StudySettingsDto.cs
@@ -82,6 +82,9 @@ public class StudySettingsDto
     [JsonPropertyName("batchSize")]
     public int BatchSize { get; set; } = 100;
 
+    [JsonPropertyName("pauseBetweenBatches")]
+    public bool PauseBetweenBatches { get; set; } = true;
+
     [JsonPropertyName("gradingButtons")]
     public int GradingButtons { get; set; } = 4;
 

--- a/Jiten.Web/app/components/SettingsSrsStudy.vue
+++ b/Jiten.Web/app/components/SettingsSrsStudy.vue
@@ -398,6 +398,19 @@
       </div>
 
       <div class="flex items-center gap-2">
+        <ToggleSwitch v-model="form.pauseBetweenBatches" input-id="pauseBetweenBatches" />
+        <label for="pauseBetweenBatches" class="text-sm cursor-pointer">
+          Pause at the end of each batch
+          <Tooltip
+            content="When enabled, finishing a full batch shows a checkpoint so you can stop or keep going, instead of loading the next batch automatically."
+            placement="top"
+          >
+            <i class="pi pi-info-circle text-xs text-surface-400 ml-1 cursor-help" />
+          </Tooltip>
+        </label>
+      </div>
+
+      <div class="flex items-center gap-2">
         <ToggleSwitch v-model="form.countFailedReviews" input-id="countFailedReviews" />
         <label for="countFailedReviews" class="text-sm cursor-pointer">
           Count failed reviews toward daily limit

--- a/Jiten.Web/app/pages/srs/study.vue
+++ b/Jiten.Web/app/pages/srs/study.vue
@@ -392,6 +392,14 @@
     else srsStore.wrapUp();
   }
 
+  // Batch-complete checkpoint: load the next batch, or end the session (→ summary).
+  async function handleContinueBatch() {
+    await srsStore.continueBatch();
+  }
+  function handleEndSession() {
+    srsStore.endSessionFromBatch();
+  }
+
   async function exitStudy() {
     stopElapsedTimer();
     await router.push('/srs/decks');
@@ -778,6 +786,18 @@
         </div>
       </div>
     </template>
+
+    <!-- Batch-complete checkpoint (shorter sibling of the session-complete card) -->
+    <div v-else-if="srsStore.batchComplete" class="flex-1 flex items-center justify-center px-2">
+      <div class="flex flex-col items-center text-center p-6 bg-white dark:bg-gray-800 rounded-2xl shadow-lg max-w-md mx-auto w-full">
+        <div class="text-2xl font-bold mb-2">Batch complete</div>
+        <p class="text-gray-500 dark:text-gray-400 mb-6">You have completed the current batch! Would you like to stop here?</p>
+        <div class="flex gap-3 w-full">
+          <Button label="Continue" severity="secondary" class="flex-1" @click="handleContinueBatch" />
+          <Button label="End Session" class="flex-1" @click="handleEndSession" />
+        </div>
+      </div>
+    </div>
 
     <!-- No cards available -->
     <div v-else class="flex-1 flex items-center justify-center px-2">

--- a/Jiten.Web/app/stores/srsStore.ts
+++ b/Jiten.Web/app/stores/srsStore.ts
@@ -111,11 +111,18 @@ export const useSrsStore = defineStore('srs', () => {
   const isSessionComplete = ref(false);
   const isWrappingUp = ref(false);
   const preWrapUpBatch = ref<StudyCardDto[]>([]);
+  // Drives the "batch complete" checkpoint popup: set when a full batch is exhausted and the
+  // pause-between-batches setting is on, instead of transparently fetching the next batch.
+  const batchComplete = ref(false);
+  // Whether the last fetch returned a full batch (so more cards likely remain). A short batch means
+  // the queue is drained, so the boundary should complete the session rather than offer a checkpoint.
+  const lastBatchFull = ref(false);
   const settingsLoaded = ref(false);
   const studySettings = ref<StudySettingsDto>({
     newCardsPerDay: 20,
     maxReviewsPerDay: 200,
     batchSize: 100,
+    pauseBetweenBatches: true,
     gradingButtons: 4,
     interleaving: 'Mixed',
     newCardGathering: 'TopDeck',
@@ -577,6 +584,8 @@ export const useSrsStore = defineStore('srs', () => {
       isSessionComplete.value = false;
       isWrappingUp.value = false;
       preWrapUpBatch.value = [];
+      batchComplete.value = false;
+      lastBatchFull.value = false;
       againCardKeys.value = new Set();
       clearedGrades.value = [];
       undoStack.value = [];
@@ -617,6 +626,8 @@ export const useSrsStore = defineStore('srs', () => {
         currentCardIndex.value = 0;
         isSessionComplete.value = false;
       }
+      // A full batch implies more cards likely remain; a short one means the queue is drained.
+      lastBatchFull.value = response.cards.length >= effectiveLimit;
       isFlipped.value = false;
       cardShownAt.value = Date.now();
       newCardsRemaining.value = response.newCardsRemaining;
@@ -637,6 +648,33 @@ export const useSrsStore = defineStore('srs', () => {
     } finally {
       isLoading.value = false;
     }
+  }
+
+  // Decide what happens when the loaded queue runs out: finish a wrap-up, pause at a full-batch
+  // checkpoint (when the setting is on), or transparently fetch the next batch as before.
+  function onBatchExhausted() {
+    if (isWrappingUp.value) {
+      isSessionComplete.value = true;
+      return;
+    }
+    if (studySettings.value.pauseBetweenBatches && lastBatchFull.value) {
+      batchComplete.value = true;
+    } else {
+      fetchBatch();
+    }
+  }
+
+  // "Continue" from the batch-complete checkpoint: load the next batch. An empty result falls through
+  // to isSessionComplete via fetchBatch's refetch branch, so an over-optimistic lastBatchFull is safe.
+  async function continueBatch() {
+    batchComplete.value = false;
+    await fetchBatch();
+  }
+
+  // "End Session" from the batch-complete checkpoint: go straight to the session summary.
+  function endSessionFromBatch() {
+    batchComplete.value = false;
+    isSessionComplete.value = true;
   }
 
   function cardExampleKey(c: StudyCardDto) {
@@ -821,13 +859,7 @@ export const useSrsStore = defineStore('srs', () => {
       if (inFlightReviews.get(cardKey) === promise) inFlightReviews.delete(cardKey);
     });
 
-    if (currentCardIndex.value >= currentBatch.value.length) {
-      if (isWrappingUp.value) {
-        isSessionComplete.value = true;
-      } else {
-        fetchBatch();
-      }
-    }
+    if (currentCardIndex.value >= currentBatch.value.length) onBatchExhausted();
     return true;
   }
 
@@ -886,10 +918,7 @@ export const useSrsStore = defineStore('srs', () => {
         againCardKeys.value = newSet;
         clearedGrades.value = [...clearedGrades.value, 'action'];
 
-        if (currentCardIndex.value >= currentBatch.value.length) {
-          if (isWrappingUp.value) isSessionComplete.value = true;
-          else fetchBatch();
-        }
+        if (currentCardIndex.value >= currentBatch.value.length) onBatchExhausted();
       } else if (reviewResult?.intervalPreview) {
         // Patch the freshly-scheduled interval onto the re-queued card (deep-reactive via the ref).
         ctx.reinsertedAgainCard.intervalPreview = reviewResult.intervalPreview;
@@ -969,13 +998,7 @@ export const useSrsStore = defineStore('srs', () => {
 
       ensurePrefetched();
 
-      if (currentCardIndex.value >= currentBatch.value.length) {
-        if (isWrappingUp.value) {
-          isSessionComplete.value = true;
-        } else {
-          await fetchBatch();
-        }
-      }
+      if (currentCardIndex.value >= currentBatch.value.length) onBatchExhausted();
     } catch (error) {
       // The action failed before mutating local state — drop the snapshot we optimistically pushed.
       undoStack.value = undoStack.value.slice(0, -1);
@@ -1223,6 +1246,8 @@ export const useSrsStore = defineStore('srs', () => {
     preWrapUpBatch.value = blob.preWrapUpBatch ?? [];
 
     isSessionComplete.value = false;
+    batchComplete.value = false;
+    lastBatchFull.value = false;
     isFlipped.value = false;
     isLoading.value = false;
     undoStack.value = [];
@@ -1244,6 +1269,8 @@ export const useSrsStore = defineStore('srs', () => {
     isSessionComplete.value = false;
     isWrappingUp.value = false;
     preWrapUpBatch.value = [];
+    batchComplete.value = false;
+    lastBatchFull.value = false;
     againCardKeys.value = new Set();
     clearedGrades.value = [];
     sessionReviews.value = [];
@@ -1283,6 +1310,9 @@ export const useSrsStore = defineStore('srs', () => {
     isLoading,
     isSessionComplete,
     isWrappingUp,
+    batchComplete,
+    continueBatch,
+    endSessionFromBatch,
     studySettings,
     sessionStats,
     newCardsRemaining,

--- a/Jiten.Web/app/types/types.ts
+++ b/Jiten.Web/app/types/types.ts
@@ -1084,6 +1084,7 @@ export interface StudySettingsDto {
   newCardsPerDay: number;
   maxReviewsPerDay: number;
   batchSize: number;
+  pauseBetweenBatches: boolean;
   gradingButtons: number;
   interleaving: StudyInterleaving;
   newCardGathering: StudyNewCardGathering;


### PR DESCRIPTION
This adds a dialog at the end of a batch in the SRS, in which the user can either keep going and get another batch, or end their session, taking them to the end of session dialog. It follows the style of the end of session dialog.

This is a feature that at least one user was interested in, and seems reasonable to me.

<img width="400" height="400" alt="batch" src="https://github.com/user-attachments/assets/1ac2b71c-a19c-4b9e-946a-9fee7fb12973" />

Tested locally in every edge scenario I could think of without any issues. Also tested with the change from the other SRS related PR, and works smoothly with (or without) that, though that change isn't included in this PR.

Note:
- Enabled by default, but can be disabled in the settings (in the first section of SRS settings, can be moved).
- Dialog can be reworded or buttons switched as needed. I kept the continue left, end right, like the session end dialog does.