### PR TITLE
Improve stage modification recording in parser diagnostics

### DIFF
--- a/Jiten.Cli/DiagnosticTestRunner.cs
+++ b/Jiten.Cli/DiagnosticTestRunner.cs
@@ -393,7 +393,7 @@ public class DiagnosticTestRunner
                 var merges = stage.Modifications.Where(m => m.Type == "merge").ToList();
                 foreach (var merge in merges)
                 {
-                    return $"Stage '{stage.StageName}' merged [{string.Join(", ", merge.InputTokens)}] → '{merge.OutputToken}'";
+                    return $"Stage '{stage.StageName}' merged [{string.Join(", ", merge.InputTokens)}] → '{merge.OutputTokens.FirstOrDefault()}'";
                 }
             }
         }
@@ -501,7 +501,7 @@ public class DiagnosticTestRunner
                 foreach (var stage in diagnostics.TokenStages)
                 {
                     var merge = stage.Modifications.FirstOrDefault(m =>
-                                                                       m.Type == "merge" && m.OutputToken == actualToken);
+                                                                       m.Type == "merge" && m.OutputTokens is [var mergedToken] && mergedToken == actualToken);
                     if (merge != null)
                     {
                         sb.AppendLine($"// Caused by stage: {stage.StageName}");

--- a/Jiten.Parser/Diagnostics/ParserDiagnostics.cs
+++ b/Jiten.Parser/Diagnostics/ParserDiagnostics.cs
@@ -151,6 +151,15 @@ public class TokenProcessingStage
     public int OutputTokenCount { get; set; }
     public List<TokenModification> Modifications { get; set; } = [];
 
+    /// Full token surfaces entering/leaving the stage. Serialized only when the
+    /// stage changed something — unchanged stages carry state forward implicitly,
+    /// so consumers can reconstruct the exact token list at every pipeline point.
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<string>? InputTokens { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<string>? OutputTokens { get; set; }
+
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public bool Skipped { get; set; }
 }
@@ -160,9 +169,15 @@ public class TokenProcessingStage
 /// </summary>
 public class TokenModification
 {
-    public string Type { get; set; } = string.Empty; // "merge", "split", "reclassify", "remove"
+    public string Type { get; set; } = string.Empty; // "merge", "split", "remove", "insert", "replace", "resegment", "reclassify"
     public string[] InputTokens { get; set; } = [];
-    public string? OutputToken { get; set; }
+    public string[] OutputTokens { get; set; } = [];
+
+    /// Positions of the affected run in the stage's input/output token lists,
+    /// so repeated surfaces stay unambiguous for consumers.
+    public int InputIndex { get; set; }
+    public int OutputIndex { get; set; }
+
     public string Reason { get; set; } = string.Empty;
 }
 

--- a/Jiten.Parser/Helpers/MorphologicalAnalyser.Diagnostics.cs
+++ b/Jiten.Parser/Helpers/MorphologicalAnalyser.Diagnostics.cs
@@ -1,5 +1,5 @@
 using System.Diagnostics;
-using System.Text;
+using Jiten.Core.Data;
 using Jiten.Parser.Diagnostics;
 
 namespace Jiten.Parser;
@@ -32,7 +32,7 @@ public partial class MorphologicalAnalyser
 
     private static List<WordInfo> TrackStage(TokenStage stage, List<WordInfo> input, ParserDiagnostics? diagnostics)
     {
-        var inputSnapshot = diagnostics != null ? input.Select(w => w.Text).ToList() : null;
+        var inputSnapshot = diagnostics != null ? input.Select(TokenSnapshot.From).ToList() : null;
         var sw = diagnostics != null ? Stopwatch.StartNew() : null;
 
         var result = stage.Apply(input);
@@ -41,7 +41,8 @@ public partial class MorphologicalAnalyser
             return result;
 
         sw!.Stop();
-        var outputSnapshot = result.Select(w => w.Text).ToList();
+        var outputSnapshot = result.Select(TokenSnapshot.From).ToList();
+        var modifications = DetectModifications(inputSnapshot!, outputSnapshot);
         diagnostics.TokenStages.Add(new TokenProcessingStage
         {
             StageName = stage.Name,
@@ -49,61 +50,175 @@ public partial class MorphologicalAnalyser
             ElapsedMs = sw.Elapsed.TotalMilliseconds,
             InputTokenCount = inputSnapshot!.Count,
             OutputTokenCount = outputSnapshot.Count,
-            Modifications = DetectModifications(inputSnapshot, outputSnapshot)
+            Modifications = modifications,
+            InputTokens = modifications.Count > 0 ? inputSnapshot.Select(s => s.Text).ToList() : null,
+            OutputTokens = modifications.Count > 0 ? outputSnapshot.Select(s => s.Text).ToList() : null
         });
 
         return result;
     }
 
-    private static List<TokenModification> DetectModifications(List<string> inputTokens, List<string> outputTokens)
+    internal readonly record struct TokenSnapshot(
+        string Text, PartOfSpeech PartOfSpeech, PartOfSpeechSection PartOfSpeechSection1, string Reading,
+        string DictionaryForm, string NormalizedForm, int? PreMatchedWordId, byte? PreMatchedReadingIndex, bool IsInvalid)
     {
-        var modifications = new List<TokenModification>();
+        public static TokenSnapshot From(WordInfo w) =>
+            new(w.Text, w.PartOfSpeech, w.PartOfSpeechSection1, w.Reading,
+                w.DictionaryForm, w.NormalizedForm, w.PreMatchedWordId, w.PreMatchedReadingIndex, w.IsInvalid);
+    }
 
-        int i = 0, j = 0;
-        while (i < inputTokens.Count && j < outputTokens.Count)
+    internal static List<TokenModification> DetectModifications(List<TokenSnapshot> inputTokens, List<TokenSnapshot> outputTokens)
+    {
+        int start = 0;
+        int endIn = inputTokens.Count, endOut = outputTokens.Count;
+        while (start < endIn && start < endOut && inputTokens[start] == outputTokens[start])
+            start++;
+        while (endIn > start && endOut > start && inputTokens[endIn - 1] == outputTokens[endOut - 1])
         {
-            if (inputTokens[i] == outputTokens[j])
-            {
-                i++;
-                j++;
-                continue;
-            }
+            endIn--;
+            endOut--;
+        }
 
-            var merged = new StringBuilder();
-            var mergeStart = i;
-            while (i < inputTokens.Count && !merged.ToString().Equals(outputTokens[j]))
-            {
-                merged.Append(inputTokens[i]);
-                i++;
+        int n = endIn - start, m = endOut - start;
+        if (n == 0 && m == 0)
+            return [];
 
-                if (merged.ToString() == outputTokens[j])
+        var a = inputTokens.GetRange(start, n);
+        var b = outputTokens.GetRange(start, m);
+
+        if ((long)(n + 1) * (m + 1) > 4_000_000)
+        {
+            return
+            [
+                new TokenModification
+                {
+                    Type = "replace",
+                    InputTokens = a.Select(t => t.Text).ToArray(),
+                    OutputTokens = b.Select(t => t.Text).ToArray(),
+                    InputIndex = start, OutputIndex = start,
+                    Reason = $"{n} → {m} tokens (window too large for a detailed diff)"
+                }
+            ];
+        }
+
+        var lcs = new int[n + 1, m + 1];
+        for (int i = n - 1; i >= 0; i--)
+            for (int j = m - 1; j >= 0; j--)
+                lcs[i, j] = a[i].Text == b[j].Text ? lcs[i + 1, j + 1] + 1 : Math.Max(lcs[i + 1, j], lcs[i, j + 1]);
+
+        var modifications = new List<TokenModification>();
+        int x = 0, y = 0;
+        while (x < n || y < m)
+        {
+            if (x < n && y < m && a[x].Text == b[y].Text)
+            {
+                if (a[x] != b[y])
                 {
                     modifications.Add(new TokenModification
                                       {
-                                          Type = "merge", InputTokens = inputTokens.Skip(mergeStart).Take(i - mergeStart).ToArray(),
-                                          OutputToken = outputTokens[j], Reason = $"Merged {i - mergeStart} tokens"
+                                          Type = "reclassify", InputTokens = [a[x].Text], OutputTokens = [b[y].Text],
+                                          InputIndex = start + x, OutputIndex = start + y,
+                                          Reason = DescribeAttributeChange(a[x], b[y])
                                       });
-                    j++;
-                    break;
                 }
+
+                x++;
+                y++;
+                continue;
             }
 
-            if (i == mergeStart)
+            int hunkX = x, hunkY = y;
+            while (x < n || y < m)
             {
-                i++;
-                j++;
+                if (x < n && y < m && a[x].Text == b[y].Text)
+                    break;
+                if (x < n && (y >= m || lcs[x + 1, y] >= lcs[x, y + 1]))
+                    x++;
+                else
+                    y++;
             }
-        }
 
-        while (i < inputTokens.Count)
-        {
-            modifications.Add(new TokenModification
-                              {
-                                  Type = "remove", InputTokens = [inputTokens[i]], OutputToken = null, Reason = "Token removed"
-                              });
-            i++;
+            var hunk = ClassifyHunk(a.GetRange(hunkX, x - hunkX), b.GetRange(hunkY, y - hunkY));
+            hunk.InputIndex = start + hunkX;
+            hunk.OutputIndex = start + hunkY;
+            modifications.Add(hunk);
         }
 
         return modifications;
+    }
+
+    private static string DescribeAttributeChange(TokenSnapshot before, TokenSnapshot after)
+    {
+        var parts = new List<string>();
+        if (before.PartOfSpeech != after.PartOfSpeech)
+            parts.Add($"POS {before.PartOfSpeech} → {after.PartOfSpeech}");
+        if (before.PartOfSpeechSection1 != after.PartOfSpeechSection1)
+            parts.Add($"POS section {before.PartOfSpeechSection1} → {after.PartOfSpeechSection1}");
+        if (before.Reading != after.Reading)
+            parts.Add($"reading {before.Reading} → {after.Reading}");
+        if (before.DictionaryForm != after.DictionaryForm)
+            parts.Add($"dictionary form {before.DictionaryForm} → {after.DictionaryForm}");
+        if (before.NormalizedForm != after.NormalizedForm)
+            parts.Add($"normalized form {before.NormalizedForm} → {after.NormalizedForm}");
+        if (before.PreMatchedWordId != after.PreMatchedWordId)
+            parts.Add($"pinned word {(before.PreMatchedWordId?.ToString() ?? "none")} → {(after.PreMatchedWordId?.ToString() ?? "none")}");
+        if (before.PreMatchedReadingIndex != after.PreMatchedReadingIndex)
+            parts.Add($"pinned reading {(before.PreMatchedReadingIndex?.ToString() ?? "none")} → {(after.PreMatchedReadingIndex?.ToString() ?? "none")}");
+        if (before.IsInvalid != after.IsInvalid)
+            parts.Add(after.IsInvalid ? "marked invalid" : "invalid flag cleared");
+        return string.Join("; ", parts);
+    }
+
+    private static TokenModification ClassifyHunk(List<TokenSnapshot> removedSnaps, List<TokenSnapshot> addedSnaps)
+    {
+        var removed = removedSnaps.Select(t => t.Text).ToArray();
+        var added = addedSnaps.Select(t => t.Text).ToArray();
+        bool sameText = string.Concat(removed) == string.Concat(added);
+
+        if (added.Length == 0)
+        {
+            return new TokenModification
+                   {
+                       Type = "remove", InputTokens = removed,
+                       Reason = removed.Length == 1 ? "Token removed" : $"Removed {removed.Length} tokens"
+                   };
+        }
+
+        if (removed.Length == 0)
+        {
+            return new TokenModification
+                   {
+                       Type = "insert", InputTokens = [], OutputTokens = added,
+                       Reason = $"Inserted {added.Length} token{(added.Length == 1 ? "" : "s")}"
+                   };
+        }
+
+        if (added.Length == 1)
+        {
+            return new TokenModification
+                   {
+                       Type = sameText ? "merge" : "replace", InputTokens = removed, OutputTokens = added,
+                       Reason = sameText
+                           ? $"Merged {removed.Length} tokens"
+                           : $"Rewrote {removed.Length} token{(removed.Length == 1 ? "" : "s")} in place"
+                   };
+        }
+
+        if (removed.Length == 1)
+        {
+            return new TokenModification
+                   {
+                       Type = sameText ? "split" : "replace", InputTokens = removed, OutputTokens = added,
+                       Reason = sameText ? $"Split into {added.Length} tokens" : $"Rewrote 1 token into {added.Length}"
+                   };
+        }
+
+        return new TokenModification
+               {
+                   Type = sameText ? "resegment" : "replace", InputTokens = removed, OutputTokens = added,
+                   Reason = sameText
+                       ? $"Moved boundaries across {removed.Length} → {added.Length} tokens"
+                       : $"Rewrote {removed.Length} → {added.Length} tokens"
+               };
     }
 }

--- a/Jiten.Tests/TokenModificationDetectionTests.cs
+++ b/Jiten.Tests/TokenModificationDetectionTests.cs
@@ -1,0 +1,151 @@
+using FluentAssertions;
+using Jiten.Core.Data;
+using Jiten.Parser;
+using Jiten.Parser.Diagnostics;
+
+namespace Jiten.Tests;
+
+public class TokenModificationDetectionTests
+{
+    private static MorphologicalAnalyser.TokenSnapshot Snap(
+        string text, PartOfSpeech pos = PartOfSpeech.Noun, string reading = "", string dictionaryForm = "",
+        string normalizedForm = "", int? preMatchedWordId = null, byte? preMatchedReadingIndex = null, bool isInvalid = false) =>
+        new(text, pos, default, reading, dictionaryForm, normalizedForm, preMatchedWordId, preMatchedReadingIndex, isInvalid);
+
+    private static List<TokenModification> Detect(
+        List<MorphologicalAnalyser.TokenSnapshot> input, List<MorphologicalAnalyser.TokenSnapshot> output) =>
+        MorphologicalAnalyser.DetectModifications(input, output);
+
+    [Fact]
+    public void IdenticalListsProduceNoModifications()
+    {
+        var tokens = new List<MorphologicalAnalyser.TokenSnapshot> { Snap("飲ん"), Snap("だ"), Snap("から") };
+        Detect(tokens, [.. tokens]).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AdjacentTokensMergingIsReportedAsMerge()
+    {
+        var mods = Detect([Snap("飲ん"), Snap("だ"), Snap("から")], [Snap("飲んだ"), Snap("から")]);
+
+        mods.Should().ContainSingle();
+        mods[0].Type.Should().Be("merge");
+        mods[0].InputTokens.Should().Equal("飲ん", "だ");
+        mods[0].OutputTokens.Should().Equal("飲んだ");
+        mods[0].InputIndex.Should().Be(0);
+        mods[0].OutputIndex.Should().Be(0);
+    }
+
+    [Fact]
+    public void TokenSplittingIsReportedAsSplit()
+    {
+        var mods = Detect([Snap("それ"), Snap("食べた")], [Snap("それ"), Snap("食べ"), Snap("た")]);
+
+        mods.Should().ContainSingle();
+        mods[0].Type.Should().Be("split");
+        mods[0].InputTokens.Should().Equal("食べた");
+        mods[0].OutputTokens.Should().Equal("食べ", "た");
+        mods[0].InputIndex.Should().Be(1);
+    }
+
+    [Fact]
+    public void MidListRemovalIsReported()
+    {
+        var mods = Detect([Snap("あ"), Snap("い"), Snap("う")], [Snap("あ"), Snap("う")]);
+
+        mods.Should().ContainSingle();
+        mods[0].Type.Should().Be("remove");
+        mods[0].InputTokens.Should().Equal("い");
+        mods[0].OutputTokens.Should().BeEmpty();
+        mods[0].InputIndex.Should().Be(1);
+    }
+
+    [Fact]
+    public void InsertionIsReported()
+    {
+        var mods = Detect([Snap("あ"), Snap("う")], [Snap("あ"), Snap("い"), Snap("う")]);
+
+        mods.Should().ContainSingle();
+        mods[0].Type.Should().Be("insert");
+        mods[0].OutputTokens.Should().Equal("い");
+        mods[0].OutputIndex.Should().Be(1);
+    }
+
+    [Fact]
+    public void BoundaryMoveIsReportedAsResegment()
+    {
+        var mods = Detect(
+            [Snap("愛さ"), Snap("れ"), Snap("て"), Snap("るってこと")],
+            [Snap("愛さ"), Snap("れ"), Snap("てる"), Snap("って"), Snap("こと")]);
+
+        mods.Should().ContainSingle();
+        mods[0].Type.Should().Be("resegment");
+        mods[0].InputTokens.Should().Equal("て", "るってこと");
+        mods[0].OutputTokens.Should().Equal("てる", "って", "こと");
+        mods[0].InputIndex.Should().Be(2);
+    }
+
+    [Fact]
+    public void TextRewriteIsReportedAsReplace()
+    {
+        var mods = Detect([Snap("は"), Snap("ゑ")], [Snap("は"), Snap("え")]);
+
+        mods.Should().ContainSingle();
+        mods[0].Type.Should().Be("replace");
+        mods[0].InputTokens.Should().Equal("ゑ");
+        mods[0].OutputTokens.Should().Equal("え");
+    }
+
+    [Fact]
+    public void AttributeOnlyChangeIsReportedAsReclassify()
+    {
+        var mods = Detect(
+            [Snap("猫"), Snap("通り", reading: "トオリ")],
+            [Snap("猫"), Snap("通り", reading: "ドオリ")]);
+
+        mods.Should().ContainSingle();
+        mods[0].Type.Should().Be("reclassify");
+        mods[0].InputTokens.Should().Equal("通り");
+        mods[0].Reason.Should().Contain("reading").And.Contain("トオリ").And.Contain("ドオリ");
+    }
+
+    [Fact]
+    public void PinChangeIsReportedAsReclassify()
+    {
+        var mods = Detect(
+            [Snap("通り")],
+            [Snap("通り", preMatchedWordId: 1432930)]);
+
+        mods.Should().ContainSingle();
+        mods[0].Type.Should().Be("reclassify");
+        mods[0].Reason.Should().Contain("1432930");
+    }
+
+    [Fact]
+    public void RepeatedSurfacesGetDistinctIndices()
+    {
+        var mods = Detect(
+            [Snap("は"), Snap("猫"), Snap("は")],
+            [Snap("は"), Snap("猫"), Snap("は", pos: PartOfSpeech.Particle)]);
+
+        mods.Should().ContainSingle();
+        mods[0].Type.Should().Be("reclassify");
+        mods[0].InputIndex.Should().Be(2);
+        mods[0].OutputIndex.Should().Be(2);
+    }
+
+    [Fact]
+    public void ChangesAtBothEndsSurviveTrimming()
+    {
+        var mods = Detect(
+            [Snap("次", pos: PartOfSpeech.Prefix), Snap("の"), Snap("飲ん"), Snap("だ")],
+            [Snap("次", pos: PartOfSpeech.Noun), Snap("の"), Snap("飲んだ")]);
+
+        mods.Should().HaveCount(2);
+        mods[0].Type.Should().Be("reclassify");
+        mods[0].InputIndex.Should().Be(0);
+        mods[1].Type.Should().Be("merge");
+        mods[1].InputIndex.Should().Be(2);
+        mods[1].OutputIndex.Should().Be(2);
+    }
+}


### PR DESCRIPTION
The per stage diagnostics from --parse-test only recorded limited information. This expands that information, for more useful analysis.

Example for 愛されてるってこと:

Before:
{
    "StageName": "SplitOovGarbageTokens",
    "StageGroup": "Split",
    "ElapsedMs": 1.2333,
    "InputTokenCount": 4,
    "OutputTokenCount": 5,
    "Modifications": []
  }

After:
  {
    "StageName": "SplitOovGarbageTokens",
    "StageGroup": "Split",
    "ElapsedMs": 1.3263,
    "InputTokenCount": 4,
    "OutputTokenCount": 5,
    "Modifications": [
      {
        "Type": "resegment",
        "InputTokens": ["て", "るってこと"],
        "OutputTokens": ["てる", "って", "こと"],
        "InputIndex": 2,
        "OutputIndex": 2,
        "Reason": "Moved boundaries across 2 → 3 tokens"
      }
    ],
    "InputTokens": ["愛さ", "れ", "て", "るってこと"],
    "OutputTokens": ["愛さ", "れ", "てる", "って", "こと"]
  }

Before all you really knew is that a split happened, you don't know what Sudachi / previous stages passed in, or what came out. After, you can see much more detail about what happened. In addition, stages that only affected attributes (like part of speech, reading, form) before didn't show anything, now show as Type: reclassify with a reason like "Pinned word none → 1432930"

Tests are included.

Put this together because I was trying to build a tool to visualize the pipeline in action, but noticed you couldn't really get raw info like this. 