### PR TITLE
Parser fixes!

### DIFF
--- a/Jiten.Parser/Helpers/MorphologicalAnalyser.TextProcessing.cs
+++ b/Jiten.Parser/Helpers/MorphologicalAnalyser.TextProcessing.cs
@@ -58,8 +58,11 @@ public partial class MorphologicalAnalyser
     [GeneratedRegex(@"([ァ-ヴ]ンッ)(?=[ァ-ヴぁ-ゔ\p{IsCJKUnifiedIdeographs}])")]
     private static partial Regex KatakanaInterjectionTsuRegex();
 
-    // Guard: in particle など (本などして) the ど is the 2nd mora of など, not colloquial どし(た/て/よ).
-    [GeneratedRegex(@"(?<!な)どし(?=[たてよ])")]
+    // Guard: in particle など (本などして) the ど is the 2nd mora of など, not colloquial どし(た/て/よ),
+    // and in a renyoukei + もどす compound (取りもどして, 押しもどして, 追いもどして) the どし belongs to
+    // 戻す — the class is the stem-final morae that front もどす; particles (でも, かも) never end
+    // in them, so those stay expandable.
+    [GeneratedRegex(@"(?<!な)(?<![りれびきちしい]も)どし(?=[たてよ])")]
     private static partial Regex ColloquialDoshiRegex();
 
     // ー followed by っ/っ after hiragana is emphatic/expressive (けどーっ → けど, 写るーっ → 写る)
@@ -293,7 +296,46 @@ public partial class MorphologicalAnalyser
             .Replace("んったら", $"ん{_stopToken}ったら")                 // ちゃ|んっ|たら → ちゃん + ったら
             .Replace("にいる", $"に{_stopToken}いる")                     // にいる(name 5408860) → に + いる(居る)
             .Replace("さっきこ", $"さっき{_stopToken}こ")                 // さっきこ→name さきこ(咲子) via sokuon-norm → さっき + こ(この/これ/ここ)
-            .Replace("ないっていう", $"ない{_stopToken}っていう");         // って must not attach left into 〜ない expr
+            .Replace("ないっていう", $"ない{_stopToken}っていう")          // って must not attach left into 〜ない expr
+            // Sudachi's lexicon has the kana-row nouns (ガ行, ハ行…); in hiragana running text the
+            // particle + 行〜 reading is the only real one (母が行かせまい, 聖域には行けっこない),
+            // and the split boundary is also correct before every other 行-word (が行方, は行事).
+            // The genuine row nouns stay reachable through their katakana spellings.
+            .Replace("が行", $"が{_stopToken}行")                         // ガ行(1040670) fusion → が + 行〜
+            .Replace("は行", $"は{_stopToken}行")                         // ハ行(1096940) fusion → は + 行〜
+            // 金のこ (金ノコ, hacksaw abbr) swallows the start of 金のこと; gated on the full のこと
+            // tail so a real hacksaw (金のこで切る) keeps its entry.
+            .Replace("金のこと", $"金{_stopToken}のこと")                  // お金のこと → 金 + の + こと
+            // 誰's だあれ kana form must not eat the copula of a preceding なんだ/何だ ("なんだあれ"
+            // = なんだ + あれ). Keyed on the full なんだ/何だ so a genuine child-speech だあれ after an
+            // ん-final nominal (お姉さんだあれ？) keeps 誰; a standalone だあれ？ is untouched too.
+            .Replace("なんだあれ", $"なんだ{_stopToken}あれ")              // なんだあれ → なんだ + あれ
+            .Replace("何だあれ", $"何だ{_stopToken}あれ")                  // 何だあれは → 何だ + あれ + は
+            // Sudachi's てく contraction steals the く of a following くだせえ (勘弁して|く|だ|せえ);
+            // the boundary keeps the te-form whole so the slurred 下さい can resolve as one token.
+            .Replace("てくだせえ", $"て{_stopToken}くだせえ")              // ~してくだせえ → ~して + くだせえ
+            // Dictionary-form verb + っす copula (わかるっす): Sudachi fuses るっす into a noun shard
+            // and the verb loses its final mora. る never ends a word before っす otherwise.
+            .Replace("るっす", $"る{_stopToken}っす")                      // わかるっすよ → わかる + っす + よ
+            // です steals the す of a following 済まして (顔ですましている); the sequence です+まし
+            // only exists as で + 澄まし/済まし in prose, never as polite です+まして.
+            .Replace("ですまし", $"で{_stopToken}すまし")                  // ~ですましている → で + すまして + いる
+            // ったらありゃしない ("nothing more ... than this") after an i-adjective: the いっ shard
+            // otherwise reads as 行ったら. The full-expression tail keeps 会いに行ったら untouched.
+            .Replace("いったらありゃしない", $"い{_stopToken}ったらありゃしない")
+            // Counter つ + もらう: Sudachi cuts ２つ|も|らって, feeding らって to the ラッテ loanword.
+            // つもらっ has no other reading (積もる's te-form is 積もって).
+            .Replace("つもらっ", $"つ{_stopToken}もらっ")
+            // Desiderative たい before a quotative って: Sudachi hands the い to 行って
+            // (知りた|いって, 会いた|いって, 見た|いって). Splitting is correct in every reading —
+            // an adjective tail (重たいって) and kana 鯛って take the same cut.
+            .Replace("たいって", $"たい{_stopToken}って")
+            // Dictionary-form verb + っていう (あるっていうなら): Sudachi fuses るっていう into a blob
+            // that drops; る never ends a word before っていう otherwise.
+            .Replace("るっていう", $"る{_stopToken}っていう")
+            // 病は気から + quotative って: Sudachi's fused からって ("just because") consumes the
+            // proverb's tail; the boundary restores から + って after the topic-marked 気.
+            .Replace("は気からって", $"は気から{_stopToken}って");
         text = TooriQuotativeRegex().Replace(text, _stopToken);
         text = VowelTailKatakanaBoundaryRegex().Replace(text, _stopToken);
         text = MoshiKatakanaBoundaryRegex().Replace(text, $"もし{_stopToken}");

--- a/Jiten.Parser/Parser.cs
+++ b/Jiten.Parser/Parser.cs
@@ -2785,10 +2785,15 @@ namespace Jiten.Parser
                 {
                     var word = wordInfos[i];
 
+                    // NaAdjective anchors expression windows too (見るも無残, 傍若無人ぶり): a span
+                    // ending on a na-adjective could otherwise never match its expression entry.
+                    // It is expression-only like the noun trigger — plain-compound absorption from a
+                    // na-adjective anchor would over-merge the same way nouns would.
                     if (word.PartOfSpeech is PartOfSpeech.Verb or PartOfSpeech.IAdjective or PartOfSpeech.Expression or PartOfSpeech.Suffix
-                        or PartOfSpeech.Noun or PartOfSpeech.CommonNoun or PartOfSpeech.Name)
+                        or PartOfSpeech.Noun or PartOfSpeech.CommonNoun or PartOfSpeech.Name or PartOfSpeech.NaAdjective)
                     {
-                        bool nounTrigger = word.PartOfSpeech is PartOfSpeech.Noun or PartOfSpeech.CommonNoun or PartOfSpeech.Name;
+                        bool nounTrigger = word.PartOfSpeech is PartOfSpeech.Noun or PartOfSpeech.CommonNoun or PartOfSpeech.Name
+                            or PartOfSpeech.NaAdjective;
                         var match = TryMatchCompounds(wordInfos, i, tokenHashes, forceExpressionOnly: nounTrigger);
 
                         // A hard-pinned token is a gate's final word decision; a compound must not
@@ -2861,7 +2866,7 @@ namespace Jiten.Parser
         // entry existence because many X+に pairs have genuine case-particle readings that an
         // automatic merge would destroy (それに気づいた, ことに決めた, 外に出る). Pairs whose
         // combined surface is effectively always the adverb (絶対に) are safe to list.
-        private static readonly HashSet<string> LexicalizedAdverbPairs = ["フルに", "無性に", "意地でも", "絶対に"];
+        private static readonly HashSet<string> LexicalizedAdverbPairs = ["フルに", "無性に", "意地でも", "絶対に", "徐々に"];
 
         /// Merges X+に into a single token when the combined surface is a lexicalized adverb:
         /// any X的+に (always adverbial, JMDict entry required) or a curated pair (フルに, 無性に,
@@ -3437,12 +3442,15 @@ namespace Jiten.Parser
                 var lastTag = form.Tags[^1];
                 if (!lastTag.StartsWith('v') && lastTag != "adj-i") continue;
                 if (!_lookups.TryGetValue(form.Text, out var ids)) continue;
-                // The conjugation-step requirement above is already a strong structural signal,
-                // so common (prioritized) verbs qualify alongside usually-kana ones (まねた →
-                // 真似る is ichi1 but not uk).
-                if (!ids.Any(id => IsKanaAppropriateId(id)
-                                   || (WordMeta.TryGetValue(id, out var meta)
-                                       && !meta.IsTrueName && meta.GetPriorityScore(true) > 0)))
+                // The deconjugation chain says the joined surface conjugates as a verb/adjective,
+                // so the rescued entry must itself be one — a noun that merely shares the base's
+                // kana (ひむ "hymn") is not a rescue target. Common (prioritized) verbs qualify
+                // alongside usually-kana ones (まねた → 真似る is ichi1 but not uk); fully-archaic
+                // scores never do.
+                if (!ids.Any(id => WordMeta.TryGetValue(id, out var meta)
+                                   && !meta.IsTrueName
+                                   && Array.Exists(meta.Pos, p => p is PartOfSpeech.Verb or PartOfSpeech.IAdjective)
+                                   && meta.GetPriorityScore(true) > (IsKanaAppropriateId(id) ? ArchaicOnlyPriorityFloor : 0)))
                     continue;
 
                 dictForm = form.Text;
@@ -3672,6 +3680,23 @@ namespace Jiten.Parser
 
         private static bool HasPrioritizedMeta(int id) =>
             WordMeta.TryGetValue(id, out var meta) && meta.GetPriorityScore(true) > 0;
+
+        // Fully-archaic entries with no frequency marker sit at ≈ −350 in WordMeta; nothing else
+        // scores below the name floor (−50). A compound whose entire entry set is that archaic is
+        // weaker evidence than the compositional parse it would replace (した+もの must not fuse
+        // into the archaic 下物).
+        private const int ArchaicOnlyPriorityFloor = -100;
+
+        // The same id must clear both bars: a span whose non-name entries are all archaic (or
+        // whose non-archaic entries are all names) rests on two different unusable entries.
+        private static bool HasUsableCompoundEntry(List<int> ids, bool isKana)
+        {
+            foreach (var id in ids)
+                if (!_nameOnlyWordIds.Contains(id)
+                    && WordMeta.TryGetValue(id, out var meta) && meta.GetPriorityScore(isKana) > ArchaicOnlyPriorityFloor)
+                    return true;
+            return false;
+        }
 
         // Applies a lookup-keyed query to the surface, falling back to its normalised-hiragana key
         // (katakana ゴロゴロ → ごろごろ) when the direct key yields nothing.
@@ -4050,7 +4075,7 @@ namespace Jiten.Parser
                         {
                             var combinedText = word.Text + sentence.Words[i + 1].word.Text;
                             if (_lookups.TryGetValue(combinedText, out var adjSuffixIds) && adjSuffixIds.Count > 0 &&
-                                !adjSuffixIds.All(id => _nameOnlyWordIds.Contains(id)))
+                                HasUsableCompoundEntry(adjSuffixIds, WanaKana.IsKana(combinedText)))
                             {
                                 var combinedReading = word.Reading + sentence.Words[i + 1].word.Reading;
                                 int combinedLength = length + sentence.Words[i + 1].length;
@@ -4116,10 +4141,11 @@ namespace Jiten.Parser
                         if (NounCompoundExclusions.Contains(combinedText))
                             continue;
 
-                        // Check if it exists in JMDict lookups — skip name-only matches
-                        // when none of the constituent tokens are name-like
+                        // Check if it exists in JMDict lookups — skip name-only matches when none
+                        // of the constituent tokens are name-like, and require a usable entry
+                        // (non-name, non-archaic) so a fully-archaic compound cannot absorb the span.
                         if (_lookups.TryGetValue(combinedText, out var wordIds) && wordIds.Count > 0 &&
-                            (hasNameLikeToken || !wordIds.All(id => _nameOnlyWordIds.Contains(id))))
+                            (hasNameLikeToken || HasUsableCompoundEntry(wordIds, WanaKana.IsKana(combinedText))))
                         {
                             bestMatch = windowSize;
                             matchedNounText = combinedText;
@@ -4131,7 +4157,7 @@ namespace Jiten.Parser
                                                                     convertLongVowelMark: false);
                         if (hiraganaText != combinedText &&
                             _lookups.TryGetValue(hiraganaText, out wordIds) && wordIds.Count > 0 &&
-                            (hasNameLikeToken || !wordIds.All(id => _nameOnlyWordIds.Contains(id))))
+                            (hasNameLikeToken || HasUsableCompoundEntry(wordIds, isKana: true)))
                         {
                             bestMatch = windowSize;
                             matchedNounText = combinedText;
@@ -4318,7 +4344,11 @@ namespace Jiten.Parser
              "虫を殺す", "むしをころす", "虫を殺し", "むしをころし",
              // 事を好む ("revel in trouble/discord") is vanishingly rare; こと is almost
              // always the nominalizer (関与することを好まない, 命令されることを好まぬ)
-             "ことを好む", "事を好む", "ことをこのむ"];
+             "ことを好む", "事を好む", "ことをこのむ",
+             // 男を知る ("to lose one's virginity") is rare; in prose the span is the literal
+             // "know this/that man" (この男を知っているか)
+             "男を知る", "男を知って", "男を知った", "男を知ってる", "男を知っている",
+             "男を知らない", "男を知り"];
 
         /// <summary>
         /// 2-token sequences combined into one expression. Curated: JMDict has entries for many
@@ -5152,12 +5182,24 @@ namespace Jiten.Parser
                 if (result.HasValue) return result;
             }
 
-            if (dictForm is "する" or "ある"
+            if (dictForm is "する" or "ある" or "いく" or "行く" or "なる" or "くる" or "来る"
                 && (verb.Text.Contains("ない") || verb.Text.Contains("なかっ") || verb.Text.Contains("なく")
                     || verb.Text.Contains("ねえ") || verb.Text.Contains("ねー") || verb.Text.Contains("ねぇ")
                     || verb.Text.Contains("ませ") || verb.Text.EndsWith("ん") || verb.Text.EndsWith("ず")))
             {
-                var negForm = dictForm == "する" ? "しない" : "ない";
+                // ん-negatives block idiom windows the same way ねぇ does: the candidate is built
+                // from the literal surface (一筋縄では+いかん never hits a lookup key), while the
+                // idioms are attested under ない (一筋縄ではいかない, うまくいかない).
+                var negForm = dictForm switch
+                {
+                    "する" => "しない",
+                    "いく" => "いかない",
+                    "行く" => "いかない",
+                    "なる" => "ならない",
+                    "くる" => "こない",
+                    "来る" => "こない",
+                    _ => "ない",
+                };
                 result = TryMatchCompoundWindow(wordInfos, wordIndex, lastConsumedIndex, negForm, forceExpressionOnly,
                     HiraRollingHash(negForm), prefCumHash, prefCumLen);
                 if (result.HasValue) return result;

--- a/Jiten.Parser/Stages/MorphologicalAnalyser.CombineStages.cs
+++ b/Jiten.Parser/Stages/MorphologicalAnalyser.CombineStages.cs
@@ -1063,6 +1063,17 @@ public partial class MorphologicalAnalyser
         return newList;
     }
 
+    // Every kanji of the surface survives into the candidate base — the base is a spelling of
+    // this surface, not merely a lemma the deconjugator can reach from it.
+    private static bool KanjiPreserved(string surface, string baseForm)
+    {
+        foreach (var c in surface)
+            if (JapaneseTextHelper.IsKanji(c) && baseForm.IndexOf(c) < 0)
+                return false;
+
+        return true;
+    }
+
     private List<WordInfo> ReclassifyOrphanedSuffixes(List<WordInfo> wordInfos)
     {
         for (int i = 1; i < wordInfos.Count; i++)
@@ -1075,8 +1086,50 @@ public partial class MorphologicalAnalyser
             if (wordInfos[i].DictionaryForm is "じまい" or "仕舞い" or "ちゃん" or "さん" or "くん" or "様" or "殿" or "氏")
                 continue;
 
-            var prev = wordInfos[i - 1].PartOfSpeech;
-            if (prev is PartOfSpeech.Noun or PartOfSpeech.CommonNoun or PartOfSpeech.Numeral or PartOfSpeech.Prefix or PartOfSpeech.Pronoun or PartOfSpeech.Suffix)
+            // A suffix is a lexical item in its own right, so its surface is attested (たち, ども,
+            // 的, 長, っぱなし). A Suffix-tagged surface that is NOT attested but deconjugates to an
+            // attested verb is a conjugated verb Sudachi bound to the preceding noun
+            // (レッテル|貼り, フライヤー|貼り) — its own spelling has no suffix entry, and the fold to
+            // one (貼り → 張り's ばり) is a different word. Route it to the verb path.
+            // Scoped to kanji-bearing surfaces whose base keeps those kanji (貼り → 貼る): that is
+            // what makes the token a spelling of the verb rather than a lemma the deconjugator
+            // merely reaches. Kana suffixes are excluded by construction — a conjugating suffix
+            // (ぶっ+た → ぶった) deconjugates to unrelated verbs (打つ) and must stay a suffix.
+            if (HasNonNameCompoundLookup != null && !HasNonNameCompoundLookup(wordInfos[i].Text)
+                && wordInfos[i].Text.Any(JapaneseTextHelper.IsKanji))
+            {
+                foreach (var form in Deconjugator.Instance.Deconjugate(wordInfos[i].Text))
+                {
+                    if (form.Text == wordInfos[i].Text || form.Text.Length < 2) continue;
+                    if (!DictionaryVerbEndings.Contains(form.Text[^1])) continue;
+                    if (!KanjiPreserved(wordInfos[i].Text, form.Text)) continue;
+                    if (!HasNonNameCompoundLookup(form.Text)) continue;
+
+                    wordInfos[i].PartOfSpeech = PartOfSpeech.Verb;
+                    wordInfos[i].PartOfSpeechSection1 = PartOfSpeechSection.None;
+                    wordInfos[i].DictionaryForm = form.Text;
+                    wordInfos[i].NormalizedForm = form.Text;
+                    wordInfos[i].Reading = string.Empty;
+                    // Same contract as the noun exit: a Sudachi-bound suffix must not anchor
+                    // compound/expression windows after reclassification.
+                    wordInfos[i].WasReclassifiedFromSuffix = true;
+                    break;
+                }
+
+                if (wordInfos[i].PartOfSpeech == PartOfSpeech.Verb)
+                    continue;
+            }
+
+            // Sudachi shreds an OOV katakana adjective into 名詞 + 接尾辞 (チッチャ|い) and then tags
+            // the following content word 接尾辞 too — a "suffix chain" anchored on an adjective
+            // tail, not a nominal host. A bare predicate ending cannot host a suffix, so it does
+            // not count as one here (車 after チッチャい must reclassify to reach its noun entry).
+            var prevInfo = wordInfos[i - 1];
+            bool prevIsPredicateTailSuffix = prevInfo.PartOfSpeech == PartOfSpeech.Suffix
+                                             && prevInfo.Text is "い" or "く" or "かっ";
+            var prev = prevInfo.PartOfSpeech;
+            if (prev is PartOfSpeech.Noun or PartOfSpeech.CommonNoun or PartOfSpeech.Numeral or PartOfSpeech.Prefix or PartOfSpeech.Pronoun
+                || (prev == PartOfSpeech.Suffix && !prevIsPredicateTailSuffix))
                 continue;
 
             // Adjectival suffixes (形容詞的) like くさい, らしい, っぽい should keep their POS

--- a/Jiten.Parser/Stages/MorphologicalAnalyser.Disambiguation.cs
+++ b/Jiten.Parser/Stages/MorphologicalAnalyser.Disambiguation.cs
@@ -776,6 +776,27 @@ public partial class MorphologicalAnalyser
                     word.Reading = "イチニチ";
             }
 
+            // 張り (バリ) → ハリ when there is nothing to bind to. The ばり suffix is bound: it
+            // attaches directly to the noun or name whose style it borrows (漱石張り, ジョーダン張り).
+            // Governed by a particle or opening a clause, the word is the standalone noun はり
+            // (tension, resilience): 張りのある声, 声に張りがある.
+            if (word is { Text: "張り", Reading: "バリ" })
+            {
+                // A quoted host still binds (「漱石」張り): look through closing quotes/brackets and
+                // the blanks the bracket handling inserts, but not across sentence punctuation —
+                // ばり attaches to an adjacent nominal.
+                int h = i - 1;
+                while (h >= 0 && (wordInfos[h].PartOfSpeech == PartOfSpeech.BlankSpace
+                                  || (wordInfos[h].Text.Length == 1 && "」』）】》〉".Contains(wordInfos[h].Text[0]))))
+                    h--;
+                var prevHost = h >= 0 ? wordInfos[h] : null;
+                if (prevHost == null
+                    || prevHost.PartOfSpeech is not (PartOfSpeech.Noun or PartOfSpeech.CommonNoun
+                        or PartOfSpeech.Name or PartOfSpeech.Pronoun or PartOfSpeech.Numeral
+                        or PartOfSpeech.Suffix))
+                    word.Reading = "ハリ";
+            }
+
             // 禍 (カ) → ワザワイ when standalone — カ reading only used in compounds (コロナ禍, 戦禍, 禍根)
             if (word is { Text: "禍", Reading: "カ" })
                 word.Reading = "ワザワイ";

--- a/Jiten.Parser/Stages/MorphologicalAnalyser.Pipeline.cs
+++ b/Jiten.Parser/Stages/MorphologicalAnalyser.Pipeline.cs
@@ -54,6 +54,7 @@ public partial class MorphologicalAnalyser
         Stage(TokenStageGroup.Repair, ApplyTokenRewriteRulesLate),
         Stage(TokenStageGroup.Repair, RepairSakkiMoraTheft, TokenFeatures.TextSakki),
         Stage(TokenStageGroup.Repair, CollapseReduplicatedMimetic, TokenFeatures.KanaRepetition),
+        Stage(TokenStageGroup.Repair, RepairClippedAdjective, TokenFeatures.EndsWithTsu),
         Stage(TokenStageGroup.Repair, RepairClassicalKiAdjective),
 
         Stage(TokenStageGroup.Combine, CombinePrefixes, TokenFeatures.Prefix),

--- a/Jiten.Parser/Stages/MorphologicalAnalyser.RepairStages.cs
+++ b/Jiten.Parser/Stages/MorphologicalAnalyser.RepairStages.cs
@@ -7,6 +7,10 @@ namespace Jiten.Parser;
 
 public partial class MorphologicalAnalyser
 {
+    // The verb heads a quotative って attaches to (言う/思う/聞く/考える/感じる); the datte-quote
+    // rewrite rule keys on the same class.
+    internal static readonly char[] QuoteVerbHeads = ['言', '思', '聞', '考', '感'];
+
     // The geminate suffixes 〜っぱなし/っぷり/っぽい attach to a verb 連用形 or noun, and Sudachi
     // routinely lets the っ (and sometimes more) bleed into the neighbours: 流|しっ|ぱなし
     // (しっ→知る), 上|が|りっぱ|な|し (りっぱ→立派), 脳天|気っぷ|り (気っぷ→気風), 皮肉っ|ぽい
@@ -4975,8 +4979,42 @@ public partial class MorphologicalAnalyser
                     }
                     else if (thief.PartOfSpeech != PartOfSpeech.Adverb)
                     {
-                        var forms = deconj.Deconjugate(stripped);
-                        shouldRepair = forms.Count > 0;
+                        // A thief that is itself a genuine te-stem — its surface + て deconjugates
+                        // back to its own dictionary form (わかっ+て → わかる) — is a verb Sudachi
+                        // got right, not a theft. The curated CommonTeFormVerbs skip only covers
+                        // the common spellings, so kana verbs outside it landed here and lost
+                        // their stem to a coincidental homograph (わか = 和歌).
+                        // …unless a quote VERB follows the て: there the quotative frame outranks
+                        // the te-form reading (かなっ|て|思ったら is かな + って + 思ったら, even
+                        // though かなって is also 叶う's te-form). The POS gate keeps nouns that
+                        // merely start with a quote-verb kanji from opening the frame (わかって
+                        // 言葉を失った must stay a te-form). The frame is deliberately broad: a
+                        // kana te-form directly governing a quote verb (わかって思った) loses its
+                        // boundary here, but narrowing it to reattachable thefts costs more real
+                        // 〜かなって思う spans than it recovers.
+                        bool quoteVerbFollows = i + 2 < wordInfos.Count
+                            && wordInfos[i + 2].PartOfSpeech == PartOfSpeech.Verb
+                            && wordInfos[i + 2].Text.Length > 0
+                            && QuoteVerbHeads.Contains(wordInfos[i + 2].Text[0]);
+
+                        bool selfTeForm = false;
+                        if (!quoteVerbFollows
+                            && thief.PartOfSpeech == PartOfSpeech.Verb && thief.DictionaryForm.Length >= 2
+                            && thief.DictionaryForm != thief.Text
+                            && HasNonNameCompoundLookup?.Invoke(thief.DictionaryForm) == true)
+                        {
+                            var dictHira = KanaConverter.ToHiragana(thief.DictionaryForm);
+                            foreach (var f in deconj.Deconjugate(KanaConverter.ToHiragana(thief.Text) + "て"))
+                            {
+                                if (f.Text == dictHira) { selfTeForm = true; break; }
+                            }
+                        }
+
+                        if (!selfTeForm)
+                        {
+                            var forms = deconj.Deconjugate(stripped);
+                            shouldRepair = forms.Count > 0;
+                        }
                     }
                     // A thief Sudachi mis-tags as an adverb but whose stripped form is itself a
                     // dictionary verb is the same stem theft one mora wider (するっ|て → する + って,
@@ -5034,6 +5072,68 @@ public partial class MorphologicalAnalyser
 
         return changed ? result : wordInfos;
     }
+
+    // Clipped exclamatory i-adjective: the colloquial stem + っ pattern (足短っ, 高っ, 寒っ)
+    // drops the い entirely, so the っ ends up a stranded symbol and the stem resolves as an
+    // unrelated noun homograph (短 → "fault; defect"). A kanji-final stem whose +い form is an
+    // attested verb or adjective is the adjective; merge and carry the dictionary form so lookup
+    // lands on it. Kana stems stay out (や|ば never forms a stem to work from).
+    private List<WordInfo> RepairClippedAdjective(List<WordInfo> wordInfos)
+    {
+        if (wordInfos.Count < 2 || HasNonNameCompoundLookup == null)
+            return wordInfos;
+
+        List<WordInfo>? result = null;
+
+        for (int i = 0; i < wordInfos.Count; i++)
+        {
+            var current = wordInfos[i];
+
+            // The っ may be separated from the stem by a forced-boundary blank.
+            int tsuIdx = -1;
+            for (int j = i + 1; j < wordInfos.Count && j <= i + 2; j++)
+            {
+                // the forced sokuon boundary leaves a stop token between stem and っ
+                if (wordInfos[j].PartOfSpeech == PartOfSpeech.BlankSpace || wordInfos[j].Text == _stopToken) continue;
+                if (wordInfos[j].Text is "っ" or "ッ") tsuIdx = j;
+                break;
+            }
+
+            if (tsuIdx < 0
+                || current.Text.Length == 0 || current.Text.Length > 4
+                || current.PreMatchedWordId != null
+                || current.PartOfSpeech is PartOfSpeech.Verb or PartOfSpeech.Particle
+                    or PartOfSpeech.Auxiliary or PartOfSpeech.Symbol or PartOfSpeech.SupplementarySymbol
+                // Kanji-final stems only: a kana stem + い hits unrelated kana keys (がんっ →
+                // がん+い = 含意) and would resurrect SFX fragments the drop gates handle.
+                || !JapaneseTextHelper.IsKanji(current.Text[^1])
+                // POS-aware: the +い form must be a verb/adjective entry, not any word — keeps
+                // noun collisions (兄い vocative) from converting a clause-initial noun + っ.
+                || HasVerbOrAdjectiveLookup?.Invoke(current.Text + "い") != true
+                // A vocative っ after a noun whose halves form an attested compound is not a
+                // clipped adjective (隊長っ: 隊+長 must re-fuse to 隊長, not become 長い).
+                || (i > 0 && HasNonNameCompoundLookup(wordInfos[i - 1].Text + current.Text)))
+            {
+                result?.Add(current);
+                continue;
+            }
+
+            result ??= [..wordInfos[..i]];
+            result.Add(new WordInfo(current)
+            {
+                Text = current.Text + "っ",
+                DictionaryForm = current.Text + "い",
+                NormalizedForm = current.Text + "い",
+                Reading = "",
+                PartOfSpeech = PartOfSpeech.IAdjective,
+                EndOffset = wordInfos[tsuIdx].EndOffset
+            });
+            i = tsuIdx;
+        }
+
+        return result ?? wordInfos;
+    }
+
 
     /// <summary>
     /// Classical attributive き fused into the following noun by the lattice: 白|き尾 → 白き|尾.

--- a/Jiten.Parser/Stages/MorphologicalAnalyser.RewriteRules.cs
+++ b/Jiten.Parser/Stages/MorphologicalAnalyser.RewriteRules.cs
@@ -265,6 +265,174 @@ public partial class MorphologicalAnalyser
             [new TokenTemplate("羽", DictForm: "羽", NormalizedForm: "羽", Pos: PartOfSpeech.Noun, Reading: "ハネ", Pin: 1171680),
              new TokenTemplate("馬車", DictForm: "馬車", NormalizedForm: "馬車", Pos: PartOfSpeech.Noun, Reading: "バシャ", Pin: 1471780)]),
 
+        // A causative + negative-volitional chain on a single-kanji stem (行かせまい) has no lattice
+        // support: Sudachi cuts 行|か|せまい and reads the tail as the adjective 狭い. Reassemble the
+        // chain. No Prev condition: the boundary split before 行 leaves a stop token there, and the
+        // hiragana せまい surface already excludes a genuine row-noun reading (…の行か、狭い… keeps
+        // 狭い in kanji or behind punctuation, so the three-token shape never arises).
+        new RewriteRule("ikasemai", RewritePhase.Cleanup,
+            [new TokenPattern(Text: "行", Pos: [PartOfSpeech.Noun, PartOfSpeech.CommonNoun]),
+             new TokenPattern(Text: "か", Pos: [PartOfSpeech.Particle]),
+             new TokenPattern(Text: "せまい")],
+            [new TokenTemplate("行かせまい", DictForm: "行く", NormalizedForm: "行く", Pos: PartOfSpeech.Verb,
+                Reading: "イカセマイ", Pin: 1578850, PinReadingIndex: 0, RecoverConjugations: true)]),
+
+        // っこない ("no way that...") after a potential/masu stem: Sudachi emits the っこ suffix and
+        // ない separately (行け|っこ|ない). The verb gate leaves nominal っこ compounds (慣れっこ,
+        // かけっこ) alone — those never sit directly on a verb token.
+        new RewriteRule("kkonai", RewritePhase.Cleanup,
+            [new TokenPattern(Text: "っこ"),
+             new TokenPattern(Text: "ない")],
+            [new TokenTemplate("っこない", DictForm: "っこない", NormalizedForm: "っこない", Pos: PartOfSpeech.Expression,
+                Reading: "ッコナイ", Pin: 2145640, PinReadingIndex: 0)],
+            Prev: new ContextCond(PosAnyOf: [PartOfSpeech.Verb])),
+
+        // Explanatory なんです (contracted な+の+です, 2683060) after nominal content. Left alone,
+        // the compound matcher absorbs なん leftward through a kana reading (居酒屋さん+なん → 三男,
+        // 俺のせい+なん → 西南). Matched on the pre-fusion shape な|ん|です, before the resegmenter
+        // fuses the tail into ですか/ですから — one rule then covers every tail instead of one per
+        // fused shape. The noun-ish Prev gate keeps interrogatives intact: これ/それ/何 are Pronoun
+        // POS and stay out, so これはなんですか still reads 何+ですか. 名前 hosts are carved out too —
+        // (お)名前なんですか is the "what is your name?" interrogative, where なん is 何.
+        new RewriteRule("nandesu", RewritePhase.Early,
+            [new TokenPattern(Text: "な"),
+             new TokenPattern(Text: "ん"),
+             new TokenPattern(Text: "です")],
+            [new TokenTemplate("なんです", DictForm: "なんです", NormalizedForm: "なんです", Pos: PartOfSpeech.Expression,
+                Reading: "ナンデス", Pin: 2683060, PinReadingIndex: 0)],
+            Prev: new ContextCond(PosAnyOf: [PartOfSpeech.Noun, PartOfSpeech.CommonNoun, PartOfSpeech.Suffix,
+                PartOfSpeech.Name, PartOfSpeech.NaAdjective]),
+            Window: new WindowCond(-1, -1, TextAnyOf: ["名前", "お名前"], Negate: true)),
+
+        // ワン公 ("doggy") is its own entry, but noun anchors only open expression windows, so the
+        // katakana bark + 公 never re-fuse at lookup (ワン "woof" + 公 "official").
+        new RewriteRule("wankou", RewritePhase.Late,
+            [new TokenPattern(Text: "ワン"),
+             new TokenPattern(Text: "公")],
+            [new TokenTemplate("ワン公", DictForm: "ワン公", NormalizedForm: "ワン公", Pos: PartOfSpeech.Noun,
+                Reading: "ワンコウ", Pin: 2582030, PinReadingIndex: 0)]),
+
+        // 見るも無残 is its own expression. The na-adjective anchor added to the lookup window can
+        // now reach it, but only after the analyser has run — these rows settle the span earlier,
+        // before the na-adjective merge absorbs the connector な.
+        new RewriteRule("mirumo-muzan", RewritePhase.Late,
+            [new TokenPattern(Text: "見るも"),
+             new TokenPattern(Text: "無残")],
+            [new TokenTemplate("見るも無残", DictForm: "見るも無残", NormalizedForm: "見るも無残", Pos: PartOfSpeech.Expression,
+                Reading: "ミルモムザン", Pin: 2871068, PinReadingIndex: 0)]),
+        // …and the shape where the na-adjective merge already absorbed the connector (無残な).
+        new RewriteRule("mirumo-muzan-na", RewritePhase.Late,
+            [new TokenPattern(Text: "見るも"),
+             new TokenPattern(Text: "無残な")],
+            [new TokenTemplate("見るも無残", DictForm: "見るも無残", NormalizedForm: "見るも無残", Pos: PartOfSpeech.Expression,
+                Reading: "ミルモムザン", Pin: 2871068, PinReadingIndex: 0),
+             new TokenTemplate("な", DictForm: "な", NormalizedForm: "な", Pos: PartOfSpeech.Auxiliary, Reading: "ナ")]),
+
+        // 養護院-style institutional compounds: JMnedict has a place entry for the exact surface,
+        // which outranks the compositional noun+院 reading; recut. Per-surface on purpose —
+        // deciding name-vs-compositional in general needs context the parser doesn't have at
+        // token time, and a blanket recut would shred genuine name surfaces.
+        new RewriteRule("yougoin", RewritePhase.Late,
+            [new TokenPattern(Text: "養護院", RequireUnpinned: false)],
+            [new TokenTemplate("養護", DictForm: "養護", NormalizedForm: "養護", Pos: PartOfSpeech.Noun,
+                Reading: "ヨウゴ", Pin: 1605847, PinReadingIndex: 0, HardPin: true),
+             new TokenTemplate("院", DictForm: "院", NormalizedForm: "院", Pos: PartOfSpeech.Noun,
+                Reading: "イン", Pin: 2414530, PinReadingIndex: 0, HardPin: true)]),
+
+        // 打ち下ろし is the deverbal use of 打ち下ろす ("to strike down"); JMDict's only noun entry
+        // for the surface is the golf term (downhill hole), which is never the prose sense.
+        // Pin the verb so the nominalised infinitive carries the right lexeme.
+        new RewriteRule("uchioroshi", RewritePhase.Cleanup,
+            [new TokenPattern(Text: "打ち下ろし", RequireUnpinned: false)],
+            [new TokenTemplate("", DictForm: "打ち下ろす", NormalizedForm: "打ち下ろす", Pos: PartOfSpeech.Verb,
+                Reading: "ウチオロシ", Pin: 1408600, PinReadingIndex: 0, RecoverConjugations: true)]),
+
+        // Sentence-final だい (casual question particle) after the explanatory ん: the fused んだ
+        // strands the い, which then drops. Recut to nominaliser ん + だい.
+        new RewriteRule("ndai", RewritePhase.Late,
+            [new TokenPattern(Text: "んだ"),
+             new TokenPattern(Text: "い", Pos: [PartOfSpeech.Particle])],
+            [new TokenTemplate("ん", DictForm: "ん", NormalizedForm: "ん", Pos: PartOfSpeech.Particle, Reading: "ン", Pin: 2139720),
+             new TokenTemplate("だい", DictForm: "だい", NormalizedForm: "だい", Pos: PartOfSpeech.Particle,
+                Reading: "ダイ", Pin: 2097680, PinReadingIndex: 0)]),
+
+        // 出ベソ: the mixed-script uk compound is in the lookups, but noun anchors only open
+        // expression windows, so 出[Verb]+ベソ never re-fuses at lookup time.
+        new RewriteRule("debeso", RewritePhase.Late,
+            [new TokenPattern(Text: "出", Pos: [PartOfSpeech.Verb]),
+             new TokenPattern(Text: "ベソ")],
+            [new TokenTemplate("出ベソ", DictForm: "出べそ", NormalizedForm: "出べそ", Pos: PartOfSpeech.Noun,
+                Reading: "デベソ", Pin: 1340770, PinReadingIndex: 0)]),
+
+        // Kinship + 上 honorific compounds: 父上 is its own entry, but Sudachi cuts お|父|上 (the
+        // prefix combine then builds お父+上) or 父|上様. Re-cut around the 父上 unit.
+        new RewriteRule("chichiue", RewritePhase.Early,
+            [new TokenPattern(Text: "父", Pos: [PartOfSpeech.Noun, PartOfSpeech.CommonNoun]),
+             new TokenPattern(Text: "上", Pos: [PartOfSpeech.Suffix])],
+            [new TokenTemplate("父上", DictForm: "父上", NormalizedForm: "父上", Pos: PartOfSpeech.Noun,
+                Reading: "チチウエ", Pin: 1497670, PinReadingIndex: 0)]),
+        new RewriteRule("chichiue-sama", RewritePhase.Early,
+            [new TokenPattern(Text: "父", Pos: [PartOfSpeech.Noun, PartOfSpeech.CommonNoun]),
+             new TokenPattern(Text: "上様")],
+            [new TokenTemplate("父上", DictForm: "父上", NormalizedForm: "父上", Pos: PartOfSpeech.Noun,
+                Reading: "チチウエ", Pin: 1497670, PinReadingIndex: 0),
+             new TokenTemplate("様", DictForm: "様", NormalizedForm: "様", Pos: PartOfSpeech.Suffix,
+                Reading: "サマ", Pin: 1545790, PinReadingIndex: 0)]),
+
+        // Rustic くだせえ (い→え slurred 下さい): with no lattice entry Sudachi shreds it into
+        // くだ+せえ; reunite and let the deconjugator's slur fold recover the ください chain.
+        new RewriteRule("kudasee", RewritePhase.Late,
+            [new TokenPattern(Text: "くだ"),
+             new TokenPattern(Text: "せえ")],
+            [new TokenTemplate("くだせえ", DictForm: "ください", NormalizedForm: "ください", Pos: PartOfSpeech.Expression,
+                Reading: "クダセエ", Pin: 1184270, PinReadingIndex: 1, RecoverConjugations: true)]),
+
+        // Dialect continuous ちょる (=ておる) after a verb: Sudachi reads the ちょっ shard as the
+        // interjection/adverb ちょっ. The verb gate keeps the standalone interjection (ちょっ、待て)
+        // intact — that shape never follows a verb token directly.
+        new RewriteRule("chotta", RewritePhase.Late,
+            [new TokenPattern(Text: "ちょっ"),
+             new TokenPattern(Text: "た", Pos: [PartOfSpeech.Auxiliary])],
+            [new TokenTemplate("ちょった", DictForm: "ちょる", NormalizedForm: "ちょる", Pos: PartOfSpeech.Auxiliary,
+                Reading: "チョッタ", Pin: 2869627, PinReadingIndex: 0, RecoverConjugations: true)],
+            Prev: new ContextCond(PosAnyOf: [PartOfSpeech.Verb, PartOfSpeech.Auxiliary])),
+
+        // Kansai 無うなる (のうなる, "to disappear") after a subject particle: Sudachi reads
+        // の + 唸る. The particle gate leaves a genuine possessive + 唸った (彼のうなった声) alone —
+        // there the token before の is a noun, not a particle.
+        new RewriteRule("nounatta", RewritePhase.Late,
+            [new TokenPattern(Text: "の", Pos: [PartOfSpeech.Particle]),
+             new TokenPattern(TextStartsWith: "うなっ", Pos: [PartOfSpeech.Verb]),
+             new TokenPattern(Text: "た", Pos: [PartOfSpeech.Auxiliary])],
+            [new TokenTemplate("のうなった", DictForm: "のうなる", NormalizedForm: "のうなる", Pos: PartOfSpeech.Verb,
+                Reading: "ノウナッタ", Pin: 2793080, PinReadingIndex: 1, RecoverConjugations: true)],
+            // Negated nominal-host gate (same shape as tsutte-raw): a genitive/nominalising の follows
+            // nominal or predicate hosts (彼の, 見たの); after particles, adverbs, or clause-initially
+            // the の can only open のうなる (もうのうなった, 居場所がのうなった).
+            Prev: new ContextCond(PosAnyOf: [PartOfSpeech.Verb, PartOfSpeech.Auxiliary, PartOfSpeech.IAdjective,
+                PartOfSpeech.Noun, PartOfSpeech.CommonNoun, PartOfSpeech.Name, PartOfSpeech.Pronoun,
+                PartOfSpeech.NaAdjective, PartOfSpeech.Prefix, PartOfSpeech.Suffix, PartOfSpeech.Numeral,
+                PartOfSpeech.Counter], Negate: true)),
+
+        // Dialect past copula じゃった (=だった) directly after nominal content. After a verb te/ん
+        // shard it stays the contraction じゃう (飲んじゃった), which the noun-ish gate excludes.
+        new RewriteRule("jatta", RewritePhase.Late,
+            [new TokenPattern(Text: "じゃっ", Pos: [PartOfSpeech.Auxiliary]),
+             new TokenPattern(Text: "た", Pos: [PartOfSpeech.Auxiliary])],
+            [new TokenTemplate("じゃった", DictForm: "じゃった", NormalizedForm: "じゃった", Pos: PartOfSpeech.Expression,
+                Reading: "ジャッタ", Pin: 2850797, PinReadingIndex: 0)],
+            Prev: new ContextCond(PosAnyOf: [PartOfSpeech.Noun, PartOfSpeech.CommonNoun, PartOfSpeech.Name,
+                PartOfSpeech.Pronoun, PartOfSpeech.NaAdjective, PartOfSpeech.Suffix])),
+
+        // 立とうと: the volitional 立とう has no lattice support and Sudachi cuts 立|とうと, reaching
+        // the rare adverb とうと; recut so the volitional + quotative/purposive と survive.
+        new RewriteRule("tatouto", RewritePhase.Cleanup,
+            [new TokenPattern(Text: "立", Pos: [PartOfSpeech.Noun, PartOfSpeech.CommonNoun, PartOfSpeech.Name]),
+             new TokenPattern(Text: "とうと")],
+            [new TokenTemplate("立とう", DictForm: "立つ", NormalizedForm: "立つ", Pos: PartOfSpeech.Verb,
+                Reading: "タトウ", Pin: 1597040, PinReadingIndex: 0, RecoverConjugations: true),
+             new TokenTemplate("と", DictForm: "と", NormalizedForm: "と", Pos: PartOfSpeech.Particle, Reading: "ト")]),
+
         // ケダ(surname)+モノ作り mis-latticed 獣作り; re-cut to ケダモノ (獣, 1335590) + 作り. (ケダモノ alone
         // resolves correctly; only the モノ作り fusion strands ケダ on the surname.)
         new RewriteRule("kedamono", RewritePhase.Cleanup,

--- a/Jiten.Parser/Stages/MorphologicalAnalyser.SplitStages.cs
+++ b/Jiten.Parser/Stages/MorphologicalAnalyser.SplitStages.cs
@@ -157,10 +157,33 @@ public partial class MorphologicalAnalyser
                 continue;
             }
 
-            (string prefixBase, int splitAt)? split = null;
+            // An OOV compound verb carries its own surface as DictionaryForm (手に取って), so the
+            // direct lookups above miss even though the deconjugated base (手に取る) is attested.
+            // A conjugated token whose base resolves is not unresolvable — leave it whole.
+            if (dictForm == word.Text && !MorphologicalAnalyser.DictionaryVerbEndings.Contains(dictForm[^1]))
+            {
+                bool baseAttested = false;
+                foreach (var form in PipelineCachedDeconjugate(KanaConverter.ToHiragana(word.Text)))
+                {
+                    if (form.Text.Length >= 2 && form.Text != word.Text && HasCompoundLookup(form.Text))
+                    {
+                        baseAttested = true;
+                        break;
+                    }
+                }
 
-            // Prefer the longest stem (latest split point) so 縫い+止める beats 縫+い止める
-            for (int p = Math.Min(dictForm.Length - 2, word.Text.Length); p >= 1 && split == null; p--)
+                if (baseAttested)
+                {
+                    result?.Add(word);
+                    continue;
+                }
+            }
+
+            (string prefixBase, int splitAt, bool stemIsVerb)? split = null;
+
+            // Prefer the longest stem (latest split point) so 縫い+止める beats 縫+い止める.
+            // The stem stops one char short of the surface so the tail is never empty.
+            for (int p = Math.Min(dictForm.Length - 2, word.Text.Length - 1); p >= 1 && split == null; p--)
             {
                 var prefix = dictForm[..p];
                 if (!word.Text.StartsWith(prefix, StringComparison.Ordinal))
@@ -170,11 +193,11 @@ public partial class MorphologicalAnalyser
                 if (!HasNonNameCompoundLookup(suffixDict))
                     continue;
 
-                // The stem must itself be a verb: ichidan (寝→寝る) or godan renyokei (驚き→驚く)
+                // The stem is normally itself a verb: ichidan (寝→寝る) or godan renyokei (驚き→驚く)
                 var ichidan = prefix + 'る';
                 if (HasNonNameCompoundLookup(ichidan))
                 {
-                    split = (ichidan, p);
+                    split = (ichidan, p, true);
                     break;
                 }
 
@@ -182,8 +205,19 @@ public partial class MorphologicalAnalyser
                 {
                     var godan = prefix[..^1] + baseEnd;
                     if (HasNonNameCompoundLookup(godan))
-                        split = (godan, p);
+                    {
+                        split = (godan, p, true);
+                        continue;
+                    }
                 }
+
+                // …or a lexical lead that is a word in its own right — a prefix or adverb that
+                // productively fronts a verb (薄ら+笑う, もの+悲しむ). Only when the tail is itself
+                // a verb entry, so the conjugation still lands on a verb; without this the whole
+                // OOV compound drops and neither half surfaces.
+                if (prefix.Length >= 2 && HasNonNameCompoundLookup(prefix)
+                    && HasVerbOrAdjectiveLookup?.Invoke(suffixDict) == true)
+                    split = (prefix, p, false);
             }
 
             if (split == null)
@@ -194,14 +228,15 @@ public partial class MorphologicalAnalyser
 
             result ??= [..wordInfos[..idx]];
 
-            var (stemBase, at) = split.Value;
+            var (stemBase, at, stemIsVerb) = split.Value;
             var stemSurface = word.Text[..at];
             var tailSurface = word.Text[at..];
 
             result.Add(new WordInfo
             {
                 Text = stemSurface, DictionaryForm = stemBase, NormalizedForm = stemBase,
-                PartOfSpeech = PartOfSpeech.Verb, Reading = KanaConverter.ToHiragana(stemSurface),
+                PartOfSpeech = stemIsVerb ? PartOfSpeech.Verb : PartOfSpeech.Unknown,
+                Reading = KanaConverter.ToHiragana(stemSurface),
                 StartOffset = word.StartOffset,
                 EndOffset = word.StartOffset >= 0 ? word.StartOffset + at : -1
             });

--- a/Jiten.Parser/Stages/TokenStage.cs
+++ b/Jiten.Parser/Stages/TokenStage.cs
@@ -131,7 +131,8 @@ internal static class TokenFeatureScanner
 
             if (text.Contains('ー'))
                 f |= TokenFeatures.LongVowelMark;
-            if (text.Length > 0 && text[^1] == 'っ')
+            // ッ included: RepairClippedAdjective accepts a katakana sokuon token too.
+            if (text.Length > 0 && text[^1] is 'っ' or 'ッ')
                 f |= TokenFeatures.EndsWithTsu;
 
             // Candidate positions are needed only immediately before the structural block. Normal

--- a/Jiten.Tests/FormSelectionTests.cs
+++ b/Jiten.Tests/FormSelectionTests.cs
@@ -1066,7 +1066,8 @@ public class FormSelectionTests
         yield return ["強いは弱いの実", "強い", 1236070, (byte)0];
 
         // === 訳 should be わけ (1538330), not やく (2057030) in these contexts ===
-        yield return ["残念ながらそういう訳にはいかんな", "訳", 1538330, (byte)0];
+        // ん-negative folding reaches the full idiom entry (訳にはいかん = わけにはいかない).
+        yield return ["残念ながらそういう訳にはいかんな", "訳にはいかん", 2057580, (byte)0];
         yield return ["自分でも訳が分からずに", "訳", 1538330, (byte)0];
         yield return ["見間違う訳がねぇ", "訳", 1538330, (byte)0];
 
@@ -1610,7 +1611,7 @@ public class FormSelectionTests
         // Verb/adjective surfaces matched to standalone-noun/連体詞 homographs
         yield return ["意識が飛んだ。", "飛んだ", 1429700, (byte)0]; // 飛ぶ past, not とんだ 連体詞
         yield return ["「うわっ、痛ぇぇぇーーー！！」", "痛", 1432680, (byte)0]; // clipped 痛い, not -algia
-        yield return ["「暗っ！」", "暗", 1154330, (byte)0]; // clipped 暗い
+        yield return ["「暗っ！」", "暗っ", 1154330, (byte)0]; // clipped 暗い keeps its っ now
         yield return ["皿をその横に置き、てきぱきと野菜を並べた。", "置き", 1421850, (byte)0]; // 置く 連用形, not おき interval
         yield return ["強がってみせる。", "強がって", 1928800, (byte)0]; // 強がる
         yield return ["「先に行け！」", "行け", 1578850, (byte)0]; // 行く imperative, not 行ける
@@ -1759,6 +1760,92 @@ public class FormSelectionTests
         yield return ["ざまあみやがれ山犬野郎", "ざまあみやがれ", 2868161, (byte)1];
         yield return ["「そりゃいいこった」", "こった", 2106260, (byte)0];
         yield return ["ミッチーのあまりの脳天気っぷりに面食らった。", "脳天気", 2027320, (byte)2];
+        // Kana-row-noun swallow repairs: the reassembled verb chain and the っこない expression
+        // must land on their own entries, not the row nouns ガ行/ハ行 or the っこ suffix.
+        yield return ["母が行かせまいとして玄関で引き止めた。", "行かせまい", 1578850, (byte)0];
+        yield return ["どう考えても聖域には行けっこない", "っこない", 2145640, (byte)0];
+        yield return ["そんなの出来っこないよ", "出来っこない", 2063900, (byte)0];
+        // 金のこと boundary: お金 keeps its own entry (not the 金ノコ hacksaw abbreviation)
+        yield return ["ううん、お金のことじゃない。", "お金", 1001820, (byte)0];
+        // なんだ+あれ: the pronoun survives (誰's だあれ kana form must not claim the span)
+        yield return ["なんだあれ", "あれ", 1000580, (byte)2];
+        yield return ["どうにか立とうと苦心する", "立とう", 1597040, (byte)0];
+        // Explanatory なんです after nominal content resolves to its own entry; left unmerged, the
+        // compound matcher absorbs なん leftward through a kana reading (三男, 西南). The pronoun
+        // POS keeps interrogatives out: これは何ですか keeps 何.
+        yield return ["「これが居酒屋さんなんですね」", "なんです", 2683060, (byte)0];
+        yield return ["「これが居酒屋さんなんですね」", "さん", 1005340, (byte)0];
+        yield return ["「俺のせいなんですかっ！？」", "せい", 1610040, (byte)1];
+        yield return ["仕事にも学校にも行かず、家で引きこもっている人のことなんですけどね", "なんです", 2683060, (byte)0];
+        yield return ["好きなんです", "なんです", 2683060, (byte)0];
+        yield return ["これは何ですか", "何", 1577100, (byte)0];
+        // Dialect/slur family lands on the dialect entries, not the homograph shards
+        // (ちょっ interjection, 唸る, じゃう, 所為).
+        yield return ["着る物や履く物まで決められちょった。", "ちょった", 2869627, (byte)0];
+        yield return ["居場所がのうなったらしい。", "のうなった", 2793080, (byte)1];
+        yield return ["期限ちょうどの日じゃった", "じゃった", 2850797, (byte)0];
+        yield return ["もう勘弁してくだせえ", "くだせえ", 1184270, (byte)1];
+        yield return ["「読んでみればわかるっすよ。」", "っす", 2269410, (byte)0];
+        yield return ["人に預けっぱなしですましている", "すましている", 1295030, (byte)2];
+        yield return ["「まったく、恥ずかしいったらありゃしない」", "ったらありゃしない", 2229510, (byte)0];
+        yield return ["「どうしたんだい」", "だい", 2097680, (byte)0];
+        yield return ["出ベソに", "出ベソ", 1340770, (byte)0];
+        yield return ["お父上", "父上", 1497670, (byte)0];
+        yield return ["父上様", "様", 1545790, (byte)0];
+        yield return ["正体がわかって", "わかって", 1606560, (byte)4];
+        yield return ["絵本手に取ってね", "手に取って", 1895840, (byte)0];
+        // 打ち下ろし in prose is the deverbal 打ち下ろす, not the golf downhill-hole noun
+        yield return ["逆に言えば、動体に打ち下ろしを決める術理は存在しない。", "打ち下ろし", 1408600, (byte)0];
+        // Verb-lead noun merges require a non-archaic entry: した+もの stays compositional (the
+        // only entry for the fused surface is the fully-archaic 下物)
+        yield return ["紫織の攻撃力も充分すぎるほど常人離れしたものだ。", "した", 1157170, (byte)1];
+        yield return ["紫織の攻撃力も充分すぎるほど常人離れしたものだ。", "もの", 1502390, (byte)1];
+        // A Suffix tag anchored on a shredded adjective tail (チッチャ|い) is not a nominal host:
+        // 車 reclassifies and reaches its standalone noun, not the bound -しゃ suffix
+        yield return ["こんなとこチッチャい車が走るからいけねえんだ", "車", 1323080, (byte)0];
+        // ばり is a bound suffix: with no nominal host to bind to, 張り is the noun はり (tension),
+        // and Sudachi's バリ reading must not carry the suffix entry in on reading match.
+        yield return ["そして張りのある声", "張り", 1427760, (byte)0];
+        yield return ["声に張りがある", "張り", 1427760, (byte)0];
+        yield return ["漱石張りの文体だ", "張り", 1983280, (byte)0];
+        // ばり binds through a closing quote to its host
+        yield return ["「漱石」張りの文体", "張り", 1983280, (byte)0];
+        // Lexical-lead OOV compound verbs decompose instead of dropping (the lead is a prefix,
+        // not a renyoukei stem), which covers every inflection of the compound.
+        yield return ["だが薄ら笑う冷泉の神経が異様に太い", "笑う", 1351360, (byte)0];
+        yield return ["黄泉木「ブッ壊れてる」", "壊れてる", 1199900, (byte)0];
+        // なんです matched before the tail fuses, so every tail is covered by the one rule:
+        // 〜なんですから is なんです + から, not 何 + ですから.
+        yield return ["「ガルデモはあの４人だからこその調和なんですから」", "なんです", 2683060, (byte)0];
+        // 〜たいって was resolving the stolen い as 言う (1587040)
+        yield return ["あなたのこともっと知りたいって思って。", "知りたい", 1420470, (byte)0];
+        yield return ["あなたのこともっと知りたいって思って。", "って", 2086960, (byte)0];
+        // A Suffix-tagged surface that is not itself an attested word but deconjugates to an
+        // attested verb is a conjugated verb (貼り → 貼る), not the ばり suffix its normalised
+        // form folds to.
+        yield return ["「お前はレッテル貼りの達人だろ」", "貼り", 1427900, (byte)1];
+        yield return ["フライヤー貼りを再開させる", "貼り", 1427900, (byte)1];
+        // === Misparses batch 2026-08-13: lexicalized adverb, expression re-fusions, clipped
+        // adjectives, rare-idiom exclusion, place-name recut ===
+        yield return ["影が徐々に近づいてくる。", "徐々に", 1595480, (byte)0];
+        yield return ["頼んだぜワン公", "ワン公", 2582030, (byte)0];
+        yield return ["足短っ", "短っ", 1418620, (byte)0];
+        // katakana sokuon variant of the clipped adjective
+        yield return ["高ッ、この店", "高っ", 1283190, (byte)0];
+        // だあれ (誰) survives after an ん-final nominal; only なんだ/何だ hosts split
+        yield return ["このお姉さんだあれ？", "だあれ", 1416830, (byte)2];
+        // Noun + なんですか interrogative: 名前 hosts keep 何 (carved out of the なんです merge)
+        yield return ["お名前なんですか？", "なん", 2846738, (byte)1];
+        // quote-verb bypass is POS-gated: a noun starting with 言 doesn't reopen the theft
+        yield return ["意味がわかって言葉を失った", "わかって", 1606560, (byte)4];
+        yield return ["寒っ", "寒っ", 1210360, (byte)0];
+        yield return ["見るも無残な子グリフォン", "見るも無残", 2871068, (byte)0];
+        yield return ["「この男を知っているか？」", "男", 1419990, (byte)0];
+        yield return ["各養護院に引き取られることになっている。", "養護", 1605847, (byte)0];
+        yield return ["話にならん", "話にならん", 2223720, (byte)0];
+        yield return ["田中さんじゃった", "じゃった", 2850797, (byte)0];
+        yield return ["もうのうなった", "のうなった", 2793080, (byte)1];
+        yield return ["見るも無残だった", "見るも無残", 2871068, (byte)0];
         yield return ["俺の皮肉っぽい言い方に、むっとしたのがわかった。", "っぽい", 2083720, (byte)0];
         yield return ["立派な人になりたい。", "立派な", 1551790, (byte)0];
         yield return ["ちっぽけな家に住んでいる。", "ちっぽけな", 1007570, (byte)1];
@@ -1814,8 +1901,8 @@ public class FormSelectionTests
         yield return ["否定はしませぬ", "しませぬ", 1157170, (byte)1];
         // Polite かもしれません is its own expression (1002975); the plain かもしれない (1002970) still combines
         yield return ["同じなのかもしれませんしね", "かもしれません", 1002975, (byte)1];
-        // 合 after 死 is the 合い suffix あい (死合=しあい), not the volume unit ごう
-        yield return ["竜胆はこの死合の果てに", "合", 1284320, (byte)1];
+        // 死合 has its own entry since the 2026-08 JMdict update; the whole compound wins
+        yield return ["竜胆はこの死合の果てに", "死合", 2872098, (byte)0];
         // 直+copula に is 直に じかに (1430690), not 直(ちょく)+に
         yield return ["その熱量を直に感じ取ってみる", "直に", 1430690, (byte)0];
         // bare 有り得 at a clause end is its own entry (2560320), not 有り得る

--- a/Jiten.Tests/MorphologicalAnalyserTests.cs
+++ b/Jiten.Tests/MorphologicalAnalyserTests.cs
@@ -338,13 +338,13 @@ public class MorphologicalAnalyserTests
         // (なる→な+るって) or an interjection (従→従+えっ+て): the verb must be rescued whole and って
         // kept as a particle, never dropped as an unresolvable blob.
         // yield return ["貴方たちって民主主義を否定する", new[] { "貴方たち", "って", "民主主義", "を", "否定する" }];
-        yield return ["展開されているっていうのは", new[] { "展開されて", "いる", "っていう", "の", "は" }];
-        yield return ["ようにしてあるっていうだけでも", new[] { "ようにして", "ある", "っていう", "だけ", "でも" }];
+        yield return ["展開されているっていうのは", new[] { "展開されている", "っていう", "の", "は" }];
+        yield return ["ようにしてあるっていうだけでも", new[] { "ようにしてある", "っていう", "だけ", "でも" }];
         yield return ["お嫁さんになるって約束した", new[] { "お嫁さん", "に", "なる", "って", "約束した" }];
         yield return ["癇に障るってのはわかる", new[] { "癇に障る", "ってのは", "わかる" }];
         yield return ["指示に従えってことか", new[] { "指示", "に", "従え", "って", "こと", "か" }];
         yield return ["殴り合えってわけだな", new[] { "殴り合え", "って", "わけ", "だ", "な" }];
-        yield return ["寄ってくるっていう話", new[] { "寄って", "くる", "っていう", "話" }];
+        yield return ["寄ってくるっていう話", new[] { "寄ってくる", "っていう", "話" }];
         // Godan verbs whose final mora Sudachi strands onto the って thief (mis-tagged
         // interjection/adverb/auxiliary): the verb must be reconstituted, not dropped.
         yield return ["読むって約束した", new[] { "読む", "って", "約束した" }];
@@ -564,7 +564,8 @@ public class MorphologicalAnalyserTests
         yield return ["雪がないため", new[] { "雪", "が", "ない", "ため" }];
         yield return ["雪がなく", new[] { "雪", "が", "なく" }];
         yield return ["零れ落ちてる", new[] { "零れ落ちてる" }];
-        yield return ["使い物にならんだろ", new[] { "使い物", "に", "ならん", "だろ" }];
+        // the なる negative fold now reaches the idiom entry (使い物にならない 1894370)
+        yield return ["使い物にならんだろ", new[] { "使い物にならん", "だろ" }];
         yield return ["私とならんで走った", new[] { "私", "と", "ならんで", "走った" }];
         yield return ["のうえに", new[] { "の", "うえ", "に" }];
         yield return ["皇位についたが", new[] { "皇位", "に", "ついた", "が" }];
@@ -1322,7 +1323,8 @@ public class MorphologicalAnalyserTests
         yield return ["創造主たる", new[] { "創造主", "たる" }];
 
         // === Colloquial どした = どうした ===
-        yield return ["どしたんだい", new[] { "どう", "した", "んだ" }];
+        // the だい recut keeps the final い as its own question particle (どうしたん + だい)
+        yield return ["どしたんだい", new[] { "どうしたん", "だい" }];
         yield return ["どして俺がいると", new[] { "どうして", "俺", "が", "いる", "と" }];
 
         // === Yojijukugo 完全無欠 should be 1 word (na-adj + な merges naturally) ===
@@ -2040,6 +2042,106 @@ public class MorphologicalAnalyserTests
         // An OOV X返る intensifier compound (Sudachi norm のさばり返る) has no JMDict entry and dropped
         // whole; split into head verb + 返る, folding the following て into 返って (not a quotative って).
         yield return ["のさばりかえっている", new[] { "のさばり", "かえっている" }];
+        // Sudachi's kana-row nouns (ガ行, ハ行) swallow a hiragana particle before 行〜; the
+        // pre-tokenisation boundary keeps particle + verb apart, and the causative +
+        // negative-volitional chain (行かせまい) reassembles from the 行|か|せまい shreds.
+        yield return ["母が行かせまいとして玄関で引き止めた。", new[] { "母", "が", "行かせまい", "として", "玄関", "で", "引き止めた" }];
+        // The が行 fusion is context-dependent — after a name Sudachi really does emit ガ行,
+        // so this shape (not the 母 one) is what the boundary has to hold.
+        yield return ["近くにいたなら、例え妹の穂香が行かせまいとしても",
+            new[] { "近く", "に", "いた", "なら", "例え", "妹", "の", "穂香", "が", "行かせまい", "としても" }];
+        yield return ["Ｊｒ．何だあれは", new[] { "何", "だ", "あれ", "は" }];
+        yield return ["だが薄ら笑って見せた", new[] { "だが", "薄ら", "笑って", "見せた" }];
+        yield return ["薄ら笑った顔", new[] { "薄ら", "笑った", "顔" }];
+        yield return ["黄泉木「ブッ壊れてる」", new[] { "黄泉", "木", "ブッ", "壊れてる" }];
+        yield return ["せっかく岩沢さんが作った歌なんですから", new[] { "せっかく", "岩沢", "さん", "が", "作った", "歌", "なんです", "から" }];
+        // Desiderative たい keeps its い before a quotative って (Sudachi gives it to 言って);
+        // adjective tails and kana 鯛 take the same cut, so the split is safe.
+        yield return ["あなたのこともっと知りたいって思って。", new[] { "あなた", "の", "こと", "もっと", "知りたい", "って", "思って" }];
+        yield return ["会いたいって言ってた", new[] { "会いたい", "って", "言ってた" }];
+        yield return ["知りたいっていうから", new[] { "知りたい", "っていう", "から" }];
+        yield return ["重たいって", new[] { "重たい", "って" }];
+        yield return ["鯛って魚は美味しい", new[] { "鯛", "って", "魚", "は", "美味しい" }];
+        // The もどす lookbehind covers every stem-final mora that fronts it, not just り/れ/び/き/ち
+        yield return ["押しもどしてくれ", new[] { "押しもどしてくれ" }];
+        yield return ["差しもどしておく", new[] { "差しもどしておく" }];
+        // …while particles keep the colloquial どうして expansion
+        yield return ["でもどして", new[] { "でも", "どうして" }];
+        yield return ["どう考えても聖域には行けっこない", new[] { "どう考えても", "聖域", "には", "行け", "っこない" }];
+        // 金のこ (hacksaw abbr) must not eat the start of 金のこと; the boundary is gated on the
+        // full のこと tail so 金のこで切る keeps the tool entry.
+        yield return ["ううん、お金のことじゃない。", new[] { "ううん", "お金", "の", "こと", "じゃない" }];
+        // 誰's だあれ kana form must not eat the copula of a preceding なんだ/何だ.
+        yield return ["なんだあれ", new[] { "なんだ", "あれ" }];
+        // The volitional 立とう has no lattice support (Sudachi cuts 立|とうと, reaching the rare
+        // adverb とうと); the recut restores volitional + quotative と.
+        yield return ["どうにか立とうと苦心する", new[] { "どうにか", "立とう", "と", "苦心する" }];
+        // Explanatory なんです stays one unit after nominal content (noun, suffix, na-adjective);
+        // the interrogative これ/何 shapes are Pronoun POS and keep 何+ですか.
+        yield return ["「これが居酒屋さんなんですね」", new[] { "これ", "が", "居酒屋", "さん", "なんです", "ね" }];
+        yield return ["「俺のせいなんですかっ！？」", new[] { "俺", "の", "せい", "なんです", "か" }];
+        yield return ["好きなんです", new[] { "好き", "なんです" }];
+        yield return ["これは何ですか", new[] { "これ", "は", "何", "ですか" }];
+        // Dialect/slur family: ちょる (=ておる) after verbs, Kansai のうなる after a subject
+        // particle (possessive 彼の+うなった stays 唸る), past copula じゃった after nominal content
+        // (飲んじゃった keeps the じゃう contraction), slurred 下さい, ん-negative idiom folding, and
+        // the っす copula after a dictionary-form verb.
+        yield return ["着る物や履く物まで決められちょった。", new[] { "着る物", "や", "履く", "物", "まで", "決められ", "ちょった" }];
+        yield return ["居場所がのうなったらしい。", new[] { "居場所", "が", "のうなった", "らしい" }];
+        yield return ["彼のうなった声が聞こえた", new[] { "彼", "の", "うなった", "声", "が", "聞こえた" }];
+        yield return ["期限ちょうどの日じゃった", new[] { "期限", "ちょうど", "の", "日", "じゃった" }];
+        yield return ["宿題を忘れて飲んじゃった", new[] { "宿題", "を", "忘れて", "飲んじゃった" }];
+        yield return ["もう勘弁してくだせえ", new[] { "もう", "勘弁して", "くだせえ" }];
+        yield return ["この結核というやつは一筋縄ではいかん", new[] { "この", "結核", "という", "やつ", "は", "一筋縄ではいかん" }];
+        yield return ["「読んでみればわかるっすよ。」", new[] { "読んでみれば", "わかる", "っす", "よ" }];
+        // です must not steal the す of a following 済まして; ったらありゃしない keeps the preceding
+        // i-adjective whole; だい survives after the explanatory ん; kinship+上 honorifics re-cut
+        // around the 父上 unit; the mixed-script 出ベソ re-fuses onto its uk entry.
+        yield return ["人に預けっぱなしですましている", new[] { "人", "に", "預け", "っぱなし", "で", "すましている" }];
+        yield return ["「まったく、恥ずかしいったらありゃしない」", new[] { "まったく", "恥ずかしい", "ったらありゃしない" }];
+        yield return ["買いに行ったら売り切れだった", new[] { "買い", "に", "行ったら", "売り切れ", "だった" }];
+        yield return ["「どうしたんだい」", new[] { "どうしたん", "だい" }];
+        yield return ["出ベソに", new[] { "出ベソ", "に" }];
+        yield return ["お父上", new[] { "お", "父上" }];
+        yield return ["父上様", new[] { "父上", "様" }];
+        // A te-stem whose surface+て deconjugates to its own dictionary form is a genuine
+        // te-form, never quotative-って theft (わか = 和歌 must not steal the stem), and an OOV
+        // compound verb whose deconjugated base is attested is not "unresolvable".
+        yield return ["正体がわかって", new[] { "正体", "が", "わかって" }];
+        yield return ["絵本手に取ってね", new[] { "絵本", "手に取って", "ね" }];
+        yield return ["剣を打ち下ろした", new[] { "剣", "を", "打ち下ろした" }];
+        yield return ["チッチャい犬がいる", new[] { "チッチャい", "犬", "が", "いる" }];
+        // clipped exclamatory adjectives keep their っ and land on the adjective
+        yield return ["足短っ", new[] { "足", "短っ" }];
+        yield return ["高っ、この店", new[] { "高っ", "この", "店" }];
+        yield return ["高ッ、この店", new[] { "高っ", "この", "店" }];
+        yield return ["このお姉さんだあれ？", new[] { "この", "お姉さん", "だあれ" }];
+        yield return ["お名前なんですか？", new[] { "お名前", "なん", "ですか" }];
+        yield return ["意味がわかって言葉を失った", new[] { "意味", "が", "わかって", "言葉を失った" }];
+        yield return ["助けてもらって感謝している", new[] { "助けてもらって", "感謝している" }];
+        yield return ["「この男を知っているか？」", new[] { "この", "男", "を", "知っている", "か" }];
+        // Boundary/guard counter-examples: boundaries stay safe before
+        // other 行-words and the hacksaw keeps its entry outside the のこと frame; the どし
+        // lookbehind covers sibling もどす compounds; ん-negative folds reach なる idioms;
+        // suffix-hosted じゃった and the negated のうなる gate both fire; the clipped-adjective
+        // vocative gate leaves attested compounds whole.
+        yield return ["彼が行方をくらました", new[] { "彼", "が", "行方をくらました" }];
+        yield return ["金のこで枝を切った", new[] { "金のこ", "で", "枝", "を", "切った" }];
+        yield return ["竜王をたおしその手からひかりの玉を取りもどしてくれ！",
+            new[] { "竜王", "を", "たおし", "その手", "から", "ひかり", "の", "玉", "を", "取りもどしてくれ" }];
+        yield return ["犯人を引きもどして尋問した", new[] { "犯人", "を", "引きもどして", "尋問した" }];
+        yield return ["だが薄ら笑う冷泉の神経が異様に太いことだけは確かだろう。",
+            new[] { "だが", "薄ら", "笑う", "冷泉", "の", "神経", "が", "異様", "に", "太い", "こと", "だけ", "は", "確か", "だろう" }];
+        yield return ["「じゃあ、そのメンチカツを２つもらっていいですか」",
+            new[] { "じゃあ", "その", "メンチカツ", "を", "２つ", "もらって", "いい", "ですか" }];
+        yield return ["病は気からってね", new[] { "病は気から", "って", "ね" }];
+        yield return ["話にならん", new[] { "話にならん" }];
+        yield return ["田中さんじゃった", new[] { "田中", "さん", "じゃった" }];
+        yield return ["もうのうなった", new[] { "もう", "のうなった" }];
+        yield return ["見るも無残だった", new[] { "見るも無残", "だった" }];
+        yield return ["これはなんですか", new[] { "これ", "は", "なん", "ですか" }];
+        yield return ["ゆに「ちょっと子どもっぽいと思うでありますっ。黄泉木隊長っ」",
+            new[] { "に", "ちょっと", "子どもっぽい", "と", "思う", "であります", "黄泉", "木", "隊長" }];
         // A na-adjective predicate + だって before a quote verb (言う/思う/聞く/考える/感じる) is
         // copula だ + quotative って — "even exaggerated" is not a reading, so the split is unambiguous.
         yield return ["大袈裟だって言いたい", new[] { "大袈裟", "だ", "って", "言いたい" }];

--- a/Shared/resources/deconjugator.json
+++ b/Shared/resources/deconjugator.json
@@ -1661,6 +1661,14 @@
     "detail": "slang negative (shirenai)"
   },
   {
+    "type": "onlyfinalrule",
+    "dec_end": ["ください"],
+    "con_end": ["くだせえ"],
+    "dec_tag": ["exp"],
+    "con_tag": ["uninflectable"],
+    "detail": "rustic i->e slur (kudasai)"
+  },
+  {
     "type": "stdrule",
     "dec_end": ["らなければ"],
     "con_end": ["んなければ"],


### PR DESCRIPTION
Various parser fixes.

- New stage to fix adjective misparses, when they are like: 高っ (高い), 寒っ (寒い), etc. The っ was being dropped and then the remaining kanji would misparse.
- って fixing
- Fix for some compounds dropping, like 薄ら笑う. Now split instead of dropping.
- Fix for segments being merged into compounds sometimes when they shouldn't. For example した+もの often merge to 下物, an archaic word, rather than staying separate as they should.
- 徐々に merged.
- And more...

Note:
- Opinionated changes: Made it so that 男を知る doesn't parse to the expression, as the common usage of 男を知る (such as "you know this guy?") was being overriden by that expression often times. 打ち下ろし too was parsing to a golf term (downhill hole) instead of "to strike down", which would be the much more common usage, and that was addressed.
- For the segments being merged into compounds when they shouldn't fix, a merge only checked that JMdict had some entry for the combined text and that they weren't all name entries. It now requires a bare minimum of score.

All tests passed. Some old tests were updated due to improvements to parsing, and the JMdict update.