### PR TITLE
Fix: Threshold input overflow in the deck download dialog

### DIFF
--- a/Jiten.Web/app/components/MediaDeckDownloadDialog.vue
+++ b/Jiten.Web/app/components/MediaDeckDownloadDialog.vue
@@ -826,7 +826,7 @@
                   </div>
                   <div class="flex flex-col gap-1">
                     <label class="text-xs text-gray-500 dark:text-gray-400 font-medium">Threshold</label>
-                    <InputNumber v-model="occurrenceThreshold" :min="1" :useGrouping="false" class="w-full text-sm" size="small" />
+                    <InputNumber v-model="occurrenceThreshold" :min="1" :useGrouping="false" fluid class="w-full text-sm" size="small" />
                   </div>
                 </div>
                 <div class="flex flex-col gap-1">


### PR DESCRIPTION
The Occurrences threshold InputNumber was missing the fluid prop that other InputNumber in the app use. Without it, the input overflows its grid cell at narrower dialog widths.

Fixes:  #464 

 Added before and after images.

<img width="651" height="1142" alt="image" src="https://github.com/user-attachments/assets/b752804a-6a77-4bb5-bf0f-30c9ff945e0f" />

<img width="782" height="1247" alt="image" src="https://github.com/user-attachments/assets/b9b2a170-3814-490f-abd1-c867f25f7130" />
