### PR TITLE
Focus on search input after clearing it by clicking "x"

### DIFF
--- a/Jiten.Web/app/components/MediaList.vue
+++ b/Jiten.Web/app/components/MediaList.vue
@@ -63,6 +63,11 @@
   const isDescribeMode = computed(() => describeQuery.value !== null);
   const titleFilter = ref(describeQuery.value ?? (route.query.title ? (Array.isArray(route.query.title) ? route.query.title[0] : route.query.title) : null));
   const debouncedTitleFilter = ref(titleFilter.value);
+  const titleFilterInput = ref();
+  const clearTitleFilter = () => {
+    titleFilter.value = null;
+    nextTick(() => titleFilterInput.value?.$el?.focus());
+  };
 
   const sortByOptions = ref(
     [
@@ -1082,13 +1087,14 @@
             <Icon name="material-symbols:search-rounded" />
           </InputIcon>
           <InputText
+            ref="titleFilterInput"
             v-model="titleFilter"
             type="text"
             placeholder="Search by title, or describe what you want"
             aria-label="Search by title, or describe what you want"
             class="w-full"
           />
-          <InputIcon v-if="titleFilter" class="cursor-pointer" @click="titleFilter = null">
+          <InputIcon v-if="titleFilter" class="cursor-pointer" @click="clearTitleFilter">
             <Icon name="material-symbols:close" />
           </InputIcon>
         </IconField>

--- a/Jiten.Web/app/components/MediaList.vue
+++ b/Jiten.Web/app/components/MediaList.vue
@@ -5,7 +5,6 @@
   import { type Deck, MediaType, SortOrder, type Word, DisplayStyle } from '~/types';
   import Skeleton from 'primevue/skeleton';
   import Card from 'primevue/card';
-  import InputText from 'primevue/inputtext';
   import { debounce } from 'perfect-debounce';
   import { useDisplayStyleStore } from '~/stores/displayStyleStore';
   import { useJitenStore } from '~/stores/jitenStore';
@@ -63,11 +62,6 @@
   const isDescribeMode = computed(() => describeQuery.value !== null);
   const titleFilter = ref(describeQuery.value ?? (route.query.title ? (Array.isArray(route.query.title) ? route.query.title[0] : route.query.title) : null));
   const debouncedTitleFilter = ref(titleFilter.value);
-  const titleFilterInput = ref();
-  const clearTitleFilter = () => {
-    titleFilter.value = null;
-    nextTick(() => titleFilterInput.value?.$el?.focus());
-  };
 
   const sortByOptions = ref(
     [
@@ -1082,22 +1076,12 @@
         <!-- A min width rather than min-w-0: in a narrow container (the vocabulary detail page nests
            this inside a card, leaving ~314px) the field would otherwise shrink to a stub instead
            of wrapping onto its own row. -->
-        <IconField class="max-md:min-w-32 max-md:flex-1 md:w-full">
-          <InputIcon>
-            <Icon name="material-symbols:search-rounded" />
-          </InputIcon>
-          <InputText
-            ref="titleFilterInput"
-            v-model="titleFilter"
-            type="text"
-            placeholder="Search by title, or describe what you want"
-            aria-label="Search by title, or describe what you want"
-            class="w-full"
-          />
-          <InputIcon v-if="titleFilter" class="cursor-pointer" @click="clearTitleFilter">
-            <Icon name="material-symbols:close" />
-          </InputIcon>
-        </IconField>
+        <SearchInput
+          v-model="titleFilter"
+          placeholder="Search by title, or describe what you want"
+          aria-label="Search by title, or describe what you want"
+          class="max-md:min-w-32 max-md:flex-1 md:w-full"
+        />
 
         <!-- The breakpoint sits on the wrapper: PrimeVue's runtime .p-button display rule
            outranks a `hidden` utility placed on the Button itself. -->

--- a/Jiten.Web/app/components/MediaListFilterBody.vue
+++ b/Jiten.Web/app/components/MediaListFilterBody.vue
@@ -46,6 +46,12 @@
   const setRange = (key: MediaRangeKey, bounds: RangeBounds) => {
     ranges.value = { ...ranges.value, [key]: bounds };
   };
+
+  const searchInput = ref();
+  const clearSearch = () => {
+    search.value = '';
+    nextTick(() => searchInput.value?.$el?.focus());
+  };
 </script>
 
 <template>
@@ -55,6 +61,7 @@
         <Icon name="material-symbols:search-rounded" />
       </InputIcon>
       <InputText
+        ref="searchInput"
         v-model="search"
         type="text"
         placeholder="Find a filter, genre or tag..."
@@ -62,7 +69,7 @@
         class="w-full"
         :size="mobile ? undefined : 'small'"
       />
-      <InputIcon v-if="search" class="cursor-pointer" @click="search = ''">
+      <InputIcon v-if="search" class="cursor-pointer" @click="clearSearch">
         <Icon name="material-symbols:close" />
       </InputIcon>
     </IconField>

--- a/Jiten.Web/app/components/MediaListFilterBody.vue
+++ b/Jiten.Web/app/components/MediaListFilterBody.vue
@@ -47,32 +47,18 @@
     ranges.value = { ...ranges.value, [key]: bounds };
   };
 
-  const searchInput = ref();
-  const clearSearch = () => {
-    search.value = '';
-    nextTick(() => searchInput.value?.$el?.focus());
-  };
 </script>
 
 <template>
   <div :class="['flex min-h-0 flex-col', mobile ? 'gap-2' : 'gap-1.5']">
-    <IconField v-if="!split" class="shrink-0">
-      <InputIcon>
-        <Icon name="material-symbols:search-rounded" />
-      </InputIcon>
-      <InputText
-        ref="searchInput"
-        v-model="search"
-        type="text"
-        placeholder="Find a filter, genre or tag..."
-        aria-label="Find a filter, genre or tag"
-        class="w-full"
-        :size="mobile ? undefined : 'small'"
-      />
-      <InputIcon v-if="search" class="cursor-pointer" @click="clearSearch">
-        <Icon name="material-symbols:close" />
-      </InputIcon>
-    </IconField>
+    <SearchInput
+      v-if="!split"
+      v-model="search"
+      placeholder="Find a filter, genre or tag..."
+      aria-label="Find a filter, genre or tag"
+      class="shrink-0"
+      :size="mobile ? undefined : 'small'"
+    />
 
     <slot name="before" />
 

--- a/Jiten.Web/app/components/MediaListFilterPresets.vue
+++ b/Jiten.Web/app/components/MediaListFilterPresets.vue
@@ -27,11 +27,6 @@
   const saving = ref(false);
   const draftName = ref('');
   const search = ref('');
-  const searchInput = ref();
-  const clearSearch = () => {
-    search.value = '';
-    nextTick(() => searchInput.value?.$el?.focus());
-  };
   const renaming = ref<string | null>(null);
   const renameDraft = ref('');
   const deleting = ref<string | null>(null);
@@ -154,15 +149,7 @@
     </div>
 
     <div v-if="listOpen" class="flex flex-col gap-2">
-      <IconField v-if="presets.length > 8">
-        <InputIcon>
-          <Icon name="material-symbols:search-rounded" />
-        </InputIcon>
-        <InputText ref="searchInput" v-model="search" size="small" placeholder="Filter presets" aria-label="Filter presets" class="w-full" />
-        <InputIcon v-if="search" class="cursor-pointer" @click="clearSearch">
-          <Icon name="material-symbols:close" />
-        </InputIcon>
-      </IconField>
+      <SearchInput v-if="presets.length > 8" v-model="search" size="small" placeholder="Filter presets" aria-label="Filter presets" />
 
       <p v-if="!presets.length" class="text-xs text-surface-500 dark:text-surface-400">
         Nothing saved yet. Set up the filters you want, then choose Save current.

--- a/Jiten.Web/app/components/MediaListFilterPresets.vue
+++ b/Jiten.Web/app/components/MediaListFilterPresets.vue
@@ -27,6 +27,11 @@
   const saving = ref(false);
   const draftName = ref('');
   const search = ref('');
+  const searchInput = ref();
+  const clearSearch = () => {
+    search.value = '';
+    nextTick(() => searchInput.value?.$el?.focus());
+  };
   const renaming = ref<string | null>(null);
   const renameDraft = ref('');
   const deleting = ref<string | null>(null);
@@ -153,8 +158,8 @@
         <InputIcon>
           <Icon name="material-symbols:search-rounded" />
         </InputIcon>
-        <InputText v-model="search" size="small" placeholder="Filter presets" aria-label="Filter presets" class="w-full" />
-        <InputIcon v-if="search" class="cursor-pointer" @click="search = ''">
+        <InputText ref="searchInput" v-model="search" size="small" placeholder="Filter presets" aria-label="Filter presets" class="w-full" />
+        <InputIcon v-if="search" class="cursor-pointer" @click="clearSearch">
           <Icon name="material-symbols:close" />
         </InputIcon>
       </IconField>

--- a/Jiten.Web/app/components/MediaListImportPanel.vue
+++ b/Jiten.Web/app/components/MediaListImportPanel.vue
@@ -84,11 +84,6 @@
   const unmatchedOpen = ref(false);
 
   const search = ref('');
-  const searchInput = ref();
-  const clearSearch = () => {
-    search.value = '';
-    nextTick(() => searchInput.value?.$el?.focus());
-  };
   const activeView = ref<ViewKey>('import');
   const sortKey = ref<SortKey>('title');
   const sortDir = ref<SortDir>('asc');
@@ -689,15 +684,7 @@
               class="w-36 lg:!hidden"
               @update:model-value="chooseSort($event)"
             />
-            <IconField class="w-full sm:ml-auto sm:w-64">
-              <InputIcon>
-                <Icon name="material-symbols:search-rounded" />
-              </InputIcon>
-              <InputText ref="searchInput" v-model="search" type="text" placeholder="Search titles..." class="w-full" size="small" />
-              <InputIcon v-if="search" class="cursor-pointer" @click="clearSearch">
-                <Icon name="material-symbols:close" />
-              </InputIcon>
-            </IconField>
+            <SearchInput v-model="search" placeholder="Search titles..." size="small" class="w-full sm:ml-auto sm:w-64" />
           </div>
 
           <!-- Matched rows -->

--- a/Jiten.Web/app/components/MediaListImportPanel.vue
+++ b/Jiten.Web/app/components/MediaListImportPanel.vue
@@ -84,6 +84,11 @@
   const unmatchedOpen = ref(false);
 
   const search = ref('');
+  const searchInput = ref();
+  const clearSearch = () => {
+    search.value = '';
+    nextTick(() => searchInput.value?.$el?.focus());
+  };
   const activeView = ref<ViewKey>('import');
   const sortKey = ref<SortKey>('title');
   const sortDir = ref<SortDir>('asc');
@@ -688,8 +693,8 @@
               <InputIcon>
                 <Icon name="material-symbols:search-rounded" />
               </InputIcon>
-              <InputText v-model="search" type="text" placeholder="Search titles..." class="w-full" size="small" />
-              <InputIcon v-if="search" class="cursor-pointer" @click="search = ''">
+              <InputText ref="searchInput" v-model="search" type="text" placeholder="Search titles..." class="w-full" size="small" />
+              <InputIcon v-if="search" class="cursor-pointer" @click="clearSearch">
                 <Icon name="material-symbols:close" />
               </InputIcon>
             </IconField>

--- a/Jiten.Web/app/components/MediaListTagCloud.vue
+++ b/Jiten.Web/app/components/MediaListTagCloud.vue
@@ -18,6 +18,12 @@
   const emit = defineEmits<{ set: [id: number, state: TagState] }>();
 
   const search = defineModel<string>('search', { required: true });
+
+  const searchInput = ref();
+  const clearSearch = () => {
+    search.value = '';
+    nextTick(() => searchInput.value?.$el?.focus());
+  };
 </script>
 
 <template>
@@ -26,8 +32,8 @@
       <InputIcon>
         <Icon name="material-symbols:search-rounded" />
       </InputIcon>
-      <InputText v-model="search" type="text" :placeholder="placeholder" :aria-label="placeholder" class="w-full" size="small" />
-      <InputIcon v-if="search" class="cursor-pointer" @click="search = ''">
+      <InputText ref="searchInput" v-model="search" type="text" :placeholder="placeholder" :aria-label="placeholder" class="w-full" size="small" />
+      <InputIcon v-if="search" class="cursor-pointer" @click="clearSearch">
         <Icon name="material-symbols:close" />
       </InputIcon>
     </IconField>

--- a/Jiten.Web/app/components/MediaListTagCloud.vue
+++ b/Jiten.Web/app/components/MediaListTagCloud.vue
@@ -18,25 +18,11 @@
   const emit = defineEmits<{ set: [id: number, state: TagState] }>();
 
   const search = defineModel<string>('search', { required: true });
-
-  const searchInput = ref();
-  const clearSearch = () => {
-    search.value = '';
-    nextTick(() => searchInput.value?.$el?.focus());
-  };
 </script>
 
 <template>
   <div class="flex min-h-0 flex-col gap-2">
-    <IconField v-if="showSearch" class="shrink-0">
-      <InputIcon>
-        <Icon name="material-symbols:search-rounded" />
-      </InputIcon>
-      <InputText ref="searchInput" v-model="search" type="text" :placeholder="placeholder" :aria-label="placeholder" class="w-full" size="small" />
-      <InputIcon v-if="search" class="cursor-pointer" @click="clearSearch">
-        <Icon name="material-symbols:close" />
-      </InputIcon>
-    </IconField>
+    <SearchInput v-if="showSearch" v-model="search" :placeholder="placeholder" :aria-label="placeholder" size="small" class="shrink-0" />
 
     <div v-if="selectedEntries.length" class="shrink-0 border-b border-surface-200 pb-2 dark:border-surface-700">
       <div class="mb-1.5 text-[11px] font-semibold tracking-wider text-surface-500 uppercase">Selected</div>

--- a/Jiten.Web/app/components/PosFilterSelect.vue
+++ b/Jiten.Web/app/components/PosFilterSelect.vue
@@ -4,6 +4,11 @@
   const model = defineModel<string[]>({ required: true });
 
   const searchQuery = ref('');
+  const searchInput = ref();
+  const clearSearch = () => {
+    searchQuery.value = '';
+    nextTick(() => searchInput.value?.$el?.focus());
+  };
   const expanded = ref<Record<string, boolean>>({});
   const toggleExpand = (key: string) => {
     expanded.value[key] = !expanded.value[key];
@@ -62,8 +67,8 @@
         <InputIcon>
           <Icon name="material-symbols:search-rounded" />
         </InputIcon>
-        <InputText v-model="searchQuery" type="text" placeholder="Search tags..." size="small" class="w-full" />
-        <InputIcon v-if="searchQuery" class="cursor-pointer" @click="searchQuery = ''">
+        <InputText ref="searchInput" v-model="searchQuery" type="text" placeholder="Search tags..." size="small" class="w-full" />
+        <InputIcon v-if="searchQuery" class="cursor-pointer" @click="clearSearch">
           <Icon name="material-symbols:close" />
         </InputIcon>
       </IconField>

--- a/Jiten.Web/app/components/PosFilterSelect.vue
+++ b/Jiten.Web/app/components/PosFilterSelect.vue
@@ -4,11 +4,6 @@
   const model = defineModel<string[]>({ required: true });
 
   const searchQuery = ref('');
-  const searchInput = ref();
-  const clearSearch = () => {
-    searchQuery.value = '';
-    nextTick(() => searchInput.value?.$el?.focus());
-  };
   const expanded = ref<Record<string, boolean>>({});
   const toggleExpand = (key: string) => {
     expanded.value[key] = !expanded.value[key];
@@ -63,15 +58,7 @@
 <template>
   <div class="border border-gray-200 dark:border-gray-700 rounded-md overflow-hidden">
     <div class="flex items-center gap-2 px-2 py-2 border-b border-gray-200 dark:border-gray-700">
-      <IconField class="flex-1">
-        <InputIcon>
-          <Icon name="material-symbols:search-rounded" />
-        </InputIcon>
-        <InputText ref="searchInput" v-model="searchQuery" type="text" placeholder="Search tags..." size="small" class="w-full" />
-        <InputIcon v-if="searchQuery" class="cursor-pointer" @click="clearSearch">
-          <Icon name="material-symbols:close" />
-        </InputIcon>
-      </IconField>
+      <SearchInput v-model="searchQuery" placeholder="Search tags..." size="small" class="flex-1" />
       <button
         v-if="model.length > 0"
         type="button"

--- a/Jiten.Web/app/components/SearchInput.vue
+++ b/Jiten.Web/app/components/SearchInput.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+  withDefaults(
+    defineProps<{
+      placeholder?: string;
+      ariaLabel?: string;
+      size?: 'small';
+      searchIconClass?: string;
+      clearIconClass?: string;
+    }>(),
+    { placeholder: 'Search' }
+  );
+
+  const model = defineModel<string>({ required: true });
+
+  const emit = defineEmits<{
+    compositionstart: [event: CompositionEvent];
+    compositionend: [event: CompositionEvent];
+  }>();
+
+  const input = ref();
+  const clear = () => {
+    model.value = '';
+    nextTick(() => input.value?.$el?.focus());
+  };
+</script>
+
+<template>
+  <IconField>
+    <InputIcon :class="searchIconClass">
+      <Icon v-if="!searchIconClass" name="material-symbols:search-rounded" />
+    </InputIcon>
+    <InputText
+      ref="input"
+      v-model="model"
+      type="text"
+      :placeholder="placeholder"
+      :aria-label="ariaLabel"
+      class="w-full"
+      :size="size"
+      @compositionstart="emit('compositionstart', $event)"
+      @compositionend="emit('compositionend', $event)"
+    />
+    <InputIcon v-if="model" :class="[clearIconClass, 'cursor-pointer']" @click="clear">
+      <Icon v-if="!clearIconClass" name="material-symbols:close" />
+    </InputIcon>
+  </IconField>
+</template>

--- a/Jiten.Web/app/components/VocabularyAdvancedFilters.vue
+++ b/Jiten.Web/app/components/VocabularyAdvancedFilters.vue
@@ -12,11 +12,6 @@
 
   const popover = ref();
   const searchQuery = ref('');
-  const searchInput = ref();
-  const clearSearch = () => {
-    searchQuery.value = '';
-    nextTick(() => searchInput.value?.$el?.focus());
-  };
   const openPanels = ref<string[]>([]);
 
   const filteredCategories = computed(() => {
@@ -122,15 +117,7 @@
         </button>
       </div>
 
-      <IconField class="w-full">
-        <InputIcon>
-          <Icon name="material-symbols:search-rounded" />
-        </InputIcon>
-        <InputText ref="searchInput" v-model="searchQuery" type="text" placeholder="Search tags..." class="w-full" />
-        <InputIcon v-if="searchQuery" class="cursor-pointer" @click="clearSearch">
-          <Icon name="material-symbols:close" />
-        </InputIcon>
-      </IconField>
+      <SearchInput v-model="searchQuery" placeholder="Search tags..." class="w-full" />
 
       <div class="flex-1 overflow-y-auto -mr-1 pr-1 max-md:min-h-0 md:min-h-[min(32rem,45vh)]">
         <Accordion v-model:value="openPanels" multiple lazy>

--- a/Jiten.Web/app/components/VocabularyAdvancedFilters.vue
+++ b/Jiten.Web/app/components/VocabularyAdvancedFilters.vue
@@ -12,6 +12,11 @@
 
   const popover = ref();
   const searchQuery = ref('');
+  const searchInput = ref();
+  const clearSearch = () => {
+    searchQuery.value = '';
+    nextTick(() => searchInput.value?.$el?.focus());
+  };
   const openPanels = ref<string[]>([]);
 
   const filteredCategories = computed(() => {
@@ -121,8 +126,8 @@
         <InputIcon>
           <Icon name="material-symbols:search-rounded" />
         </InputIcon>
-        <InputText v-model="searchQuery" type="text" placeholder="Search tags..." class="w-full" />
-        <InputIcon v-if="searchQuery" class="cursor-pointer" @click="searchQuery = ''">
+        <InputText ref="searchInput" v-model="searchQuery" type="text" placeholder="Search tags..." class="w-full" />
+        <InputIcon v-if="searchQuery" class="cursor-pointer" @click="clearSearch">
           <Icon name="material-symbols:close" />
         </InputIcon>
       </IconField>

--- a/Jiten.Web/app/components/VocabularyFilters.vue
+++ b/Jiten.Web/app/components/VocabularyFilters.vue
@@ -38,6 +38,11 @@
   };
 
   const sortPopover = ref();
+  const searchInput = ref();
+  const clearSearch = () => {
+    emit('update:search', '');
+    nextTick(() => searchInput.value?.$el?.focus());
+  };
 
   const sortLabel = computed(() => props.sortByOptions.find((o) => o.value === props.sortBy)?.label ?? 'Sort');
 
@@ -76,8 +81,14 @@
       <InputIcon>
         <Icon name="material-symbols:search-rounded" />
       </InputIcon>
-      <InputText :model-value="search" placeholder="Search words or definitions..." class="w-full" @update:model-value="$emit('update:search', $event)" />
-      <InputIcon v-if="search" class="cursor-pointer" @click="$emit('update:search', '')">
+      <InputText
+        ref="searchInput"
+        :model-value="search"
+        placeholder="Search words or definitions..."
+        class="w-full"
+        @update:model-value="$emit('update:search', $event)"
+      />
+      <InputIcon v-if="search" class="cursor-pointer" @click="clearSearch">
         <Icon name="material-symbols:close" />
       </InputIcon>
     </IconField>

--- a/Jiten.Web/app/components/VocabularyFilters.vue
+++ b/Jiten.Web/app/components/VocabularyFilters.vue
@@ -38,11 +38,10 @@
   };
 
   const sortPopover = ref();
-  const searchInput = ref();
-  const clearSearch = () => {
-    emit('update:search', '');
-    nextTick(() => searchInput.value?.$el?.focus());
-  };
+  const searchModel = computed({
+    get: () => props.search ?? '',
+    set: (v) => emit('update:search', v),
+  });
 
   const sortLabel = computed(() => props.sortByOptions.find((o) => o.value === props.sortBy)?.label ?? 'Sort');
 
@@ -77,21 +76,12 @@
       </Button>
     </div>
 
-    <IconField v-if="search !== undefined" class="flex-1 max-md:min-w-32 md:min-w-48">
-      <InputIcon>
-        <Icon name="material-symbols:search-rounded" />
-      </InputIcon>
-      <InputText
-        ref="searchInput"
-        :model-value="search"
-        placeholder="Search words or definitions..."
-        class="w-full"
-        @update:model-value="$emit('update:search', $event)"
-      />
-      <InputIcon v-if="search" class="cursor-pointer" @click="clearSearch">
-        <Icon name="material-symbols:close" />
-      </InputIcon>
-    </IconField>
+    <SearchInput
+      v-if="search !== undefined"
+      v-model="searchModel"
+      placeholder="Search words or definitions..."
+      class="flex-1 max-md:min-w-32 md:min-w-48"
+    />
 
     <div class="md:hidden shrink-0">
       <Button class="px-2!" :aria-label="`Sort by ${sortLabel}, ${sortDescending ? 'descending' : 'ascending'}`" @click="sortPopover.toggle($event)">

--- a/Jiten.Web/app/pages/dashboard/tags.vue
+++ b/Jiten.Web/app/pages/dashboard/tags.vue
@@ -21,11 +21,6 @@
   const tagUsage = ref<TagUsage | null>(null);
   const loadingUsage = ref(false);
   const searchQuery = ref('');
-  const searchInput = ref();
-  const clearSearch = () => {
-    searchQuery.value = '';
-    nextTick(() => searchInput.value?.$el?.focus());
-  };
 
   // Tag mappings dialog state
   const showMappingsDialog = ref(false);
@@ -301,15 +296,7 @@
 
     <!-- Search Bar -->
     <div class="mb-4">
-      <IconField class="w-full md:w-96">
-        <InputIcon>
-          <Icon name="material-symbols:search-rounded" />
-        </InputIcon>
-        <InputText ref="searchInput" v-model="searchQuery" type="text" placeholder="Search tags by name..." class="w-full" />
-        <InputIcon v-if="searchQuery" class="cursor-pointer" @click="clearSearch">
-          <Icon name="material-symbols:close" />
-        </InputIcon>
-      </IconField>
+      <SearchInput v-model="searchQuery" placeholder="Search tags by name..." class="w-full md:w-96" />
     </div>
 
     <DataTable

--- a/Jiten.Web/app/pages/dashboard/tags.vue
+++ b/Jiten.Web/app/pages/dashboard/tags.vue
@@ -21,6 +21,11 @@
   const tagUsage = ref<TagUsage | null>(null);
   const loadingUsage = ref(false);
   const searchQuery = ref('');
+  const searchInput = ref();
+  const clearSearch = () => {
+    searchQuery.value = '';
+    nextTick(() => searchInput.value?.$el?.focus());
+  };
 
   // Tag mappings dialog state
   const showMappingsDialog = ref(false);
@@ -300,8 +305,8 @@
         <InputIcon>
           <Icon name="material-symbols:search-rounded" />
         </InputIcon>
-        <InputText v-model="searchQuery" type="text" placeholder="Search tags by name..." class="w-full" />
-        <InputIcon v-if="searchQuery" class="cursor-pointer" @click="searchQuery = ''">
+        <InputText ref="searchInput" v-model="searchQuery" type="text" placeholder="Search tags by name..." class="w-full" />
+        <InputIcon v-if="searchQuery" class="cursor-pointer" @click="clearSearch">
           <Icon name="material-symbols:close" />
         </InputIcon>
       </IconField>

--- a/Jiten.Web/app/pages/decks/media/[id]/detail.vue
+++ b/Jiten.Web/app/pages/decks/media/[id]/detail.vue
@@ -88,11 +88,6 @@
   const subdecksRefreshing = computed(() => status.value === 'pending');
 
   const subdeckFilterInput = ref(appliedSubdeckFilter.value ?? '');
-  const subdeckFilterInputEl = ref();
-  const clearSubdeckFilter = () => {
-    subdeckFilterInput.value = '';
-    nextTick(() => subdeckFilterInputEl.value?.$el?.focus());
-  };
 
   const pushSubdeckFilter = debounce(async (value: string) => {
     await router.replace({ query: { ...route.query, subdeckFilter: value.trim() || undefined, offset: undefined } });
@@ -417,24 +412,14 @@
         </div>
         <div v-if="showSubdeckControls" class="flex flex-col gap-2 pt-2">
           <div class="flex flex-col sm:flex-row gap-2 sm:items-center">
-            <IconField class="grow">
-              <InputIcon>
-                <Icon name="material-symbols:search-rounded" />
-              </InputIcon>
-              <InputText
-                ref="subdeckFilterInputEl"
-                v-model="subdeckFilterInput"
-                type="text"
-                :placeholder="subdecksAreVideos ? 'Search videos by title or number' : 'Search subdecks by title or number'"
-                aria-label="Search subdecks"
-                class="w-full"
-                @compositionstart="subdeckFilterComposing = true"
-                @compositionend="onSubdeckFilterCompositionEnd"
-              />
-              <InputIcon v-if="subdeckFilterInput" class="cursor-pointer" @click="clearSubdeckFilter">
-                <Icon name="material-symbols:close" />
-              </InputIcon>
-            </IconField>
+            <SearchInput
+              v-model="subdeckFilterInput"
+              :placeholder="subdecksAreVideos ? 'Search videos by title or number' : 'Search subdecks by title or number'"
+              aria-label="Search subdecks"
+              class="grow"
+              @compositionstart="subdeckFilterComposing = true"
+              @compositionend="onSubdeckFilterCompositionEnd"
+            />
             <div class="flex items-center gap-2 sm:contents">
               <Select
                 :model-value="subdeckSortValue"

--- a/Jiten.Web/app/pages/decks/media/[id]/detail.vue
+++ b/Jiten.Web/app/pages/decks/media/[id]/detail.vue
@@ -88,6 +88,11 @@
   const subdecksRefreshing = computed(() => status.value === 'pending');
 
   const subdeckFilterInput = ref(appliedSubdeckFilter.value ?? '');
+  const subdeckFilterInputEl = ref();
+  const clearSubdeckFilter = () => {
+    subdeckFilterInput.value = '';
+    nextTick(() => subdeckFilterInputEl.value?.$el?.focus());
+  };
 
   const pushSubdeckFilter = debounce(async (value: string) => {
     await router.replace({ query: { ...route.query, subdeckFilter: value.trim() || undefined, offset: undefined } });
@@ -417,6 +422,7 @@
                 <Icon name="material-symbols:search-rounded" />
               </InputIcon>
               <InputText
+                ref="subdeckFilterInputEl"
                 v-model="subdeckFilterInput"
                 type="text"
                 :placeholder="subdecksAreVideos ? 'Search videos by title or number' : 'Search subdecks by title or number'"
@@ -425,7 +431,7 @@
                 @compositionstart="subdeckFilterComposing = true"
                 @compositionend="onSubdeckFilterCompositionEnd"
               />
-              <InputIcon v-if="subdeckFilterInput" class="cursor-pointer" @click="subdeckFilterInput = ''">
+              <InputIcon v-if="subdeckFilterInput" class="cursor-pointer" @click="clearSubdeckFilter">
                 <Icon name="material-symbols:close" />
               </InputIcon>
             </IconField>

--- a/Jiten.Web/app/pages/requests/index.vue
+++ b/Jiten.Web/app/pages/requests/index.vue
@@ -132,6 +132,11 @@
   const excludeOwnRequests = ref(route.query.excludeOwn === '1');
 
   const searchQuery = ref(typeof route.query.search === 'string' ? route.query.search : '');
+  const searchInput = ref();
+  const clearSearch = () => {
+    searchQuery.value = '';
+    nextTick(() => searchInput.value?.$el?.focus());
+  };
   const debouncedSearch = ref(searchQuery.value);
   let searchTimeout: ReturnType<typeof setTimeout>;
   watch(searchQuery, (val) => {
@@ -321,8 +326,8 @@
         <label class="text-sm text-muted-color">Search</label>
         <IconField>
           <InputIcon class="pi pi-search" />
-          <InputText v-model="searchQuery" placeholder="Search titles..." class="w-full" />
-          <InputIcon v-if="searchQuery" class="pi pi-times cursor-pointer" @click="searchQuery = ''" />
+          <InputText ref="searchInput" v-model="searchQuery" placeholder="Search titles..." class="w-full" />
+          <InputIcon v-if="searchQuery" class="pi pi-times cursor-pointer" @click="clearSearch" />
         </IconField>
       </div>
       <div class="flex flex-col gap-1 min-w-0">

--- a/Jiten.Web/app/pages/requests/index.vue
+++ b/Jiten.Web/app/pages/requests/index.vue
@@ -132,11 +132,6 @@
   const excludeOwnRequests = ref(route.query.excludeOwn === '1');
 
   const searchQuery = ref(typeof route.query.search === 'string' ? route.query.search : '');
-  const searchInput = ref();
-  const clearSearch = () => {
-    searchQuery.value = '';
-    nextTick(() => searchInput.value?.$el?.focus());
-  };
   const debouncedSearch = ref(searchQuery.value);
   let searchTimeout: ReturnType<typeof setTimeout>;
   watch(searchQuery, (val) => {
@@ -324,11 +319,7 @@
     <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3 my-4 items-end">
       <div class="flex flex-col gap-1 col-span-2 sm:col-span-1">
         <label class="text-sm text-muted-color">Search</label>
-        <IconField>
-          <InputIcon class="pi pi-search" />
-          <InputText ref="searchInput" v-model="searchQuery" placeholder="Search titles..." class="w-full" />
-          <InputIcon v-if="searchQuery" class="pi pi-times cursor-pointer" @click="clearSearch" />
-        </IconField>
+        <SearchInput v-model="searchQuery" placeholder="Search titles..." search-icon-class="pi pi-search" clear-icon-class="pi pi-times" />
       </div>
       <div class="flex flex-col gap-1 min-w-0">
         <label class="text-sm text-muted-color">Media Type</label>


### PR DESCRIPTION
Resolves https://github.com/Sirush/Jiten/issues/486

Note how when I click "x" I can immediately start typing:

<img width="999" height="81" alt="jiten-search" src="https://github.com/user-attachments/assets/a9d99a3a-bbe3-448c-9016-a07d42002ad9" />

Two commits here:
1. Apply this behavior to every search input, individually
2. Extract a SearchInput component to avoid duplicating this logic

I then had to solve a merge conflict so I think just keeping the first commit wouldn't work here.

Note: I used AI for this since I don't know Vue, and I'm just slightly familiar with React, but I understand what are props and events and the changes here look good to me.